### PR TITLE
Fix for strings with extra newlines/carriage returns

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -109,6 +109,7 @@ sub request {
 						elsif ($rewrite->wrap_string_callback && $rewrite->callback) {
                             $body =~ s/"/\\"/g;
                             $body =~ s/\n/\\n/g;
+							$body =~ s/\R//g;
 							$body = $rewrite->callback.'("'.$body.'");';
 						}
 						$response->code($res->code);


### PR DESCRIPTION
The \n escaping is working fine, but for HTML output that still has weird returns, Javascript will take that as a newline and throw an "Unterminated string literal" error in the browser-side. Removing \R after the \n have been escaped solves the issue.
