### PR TITLE
Web.pm - use environment proxy settings is UserAgent

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -35,6 +35,7 @@ has ua => (
 			agent => "Mozilla/5.0", #User Agent required for some API's (eg. Vimeo, IsItUp)
 			timeout => 5,
 			ssl_opts => { verify_hostname => 0 },
+			env_proxy => 1,
 		);
 	},
 );


### PR DESCRIPTION
Duckpan server running behind proxy fails to retrieve data for Spice plugins. 
