### PR TITLE
prepend optional specified libs to @INC

### DIFF
--- a/bin/duckpan
+++ b/bin/duckpan
@@ -68,7 +68,10 @@ __END__
   # Release the project of the current directory to DuckPAN
 
   duckpan -Ilib
-  # Preload an external library - intended for use during DuckPAN development
+  # Preload an external library - intended for use during DuckPAN development.
+  # Example usage inside a Goodie or Spice repository, loading edited
+  # p5-app-duckpan modules:
+      duckpan -I../p5-app-duckpan/lib server
 
   # BETA
   duckpan setup


### PR DESCRIPTION
Implemented the `-I` switch to load used modules from an arbitrary path. Helpful to shorten the otherwise lengthy test idiom while developing DuckPAN. Uses [Getopt::Long](http://perldoc.perl.org/Getopt/Long.html) from core, with "bundling" to mimic Perl invocation.

Requested in issue https://github.com/duckduckgo/p5-app-duckpan/issues/19.

Should be added to the documentation somewhere, wasn't sure what's the right place.
