### PR TITLE
ensure top level req before processing query

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -156,7 +156,7 @@ sub request {
 	} elsif ($request->param('duckduckhack_js')) {
 		$response->content_type('text/javascript');
 		$body = $self->page_js;
-	} elsif ($request->param('q')) {
+	} elsif ($request->param('q') && $request->path_info eq '/') {
 		my $query = $request->param('q');
 		Encode::_utf8_on($query);
 		my $ddg_request = DDG::Request->new(


### PR DESCRIPTION
DuckPAN is forwarding the query parameter to multiple calls for some reason (is this intended behavior?):

```
127.0.0.1 - - [07/Oct/2013:03:48:54 -0400] "GET /?duckduckhack_ignore=1&q=perl%20jobs%20in%20san%20francisco&l=us-en&p=1&s=0 HTTP/1.1" 200 0 "http://0.0.0.0:5000/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.76 Safari/537.36"
127.0.0.1 - - [07/Oct/2013:03:48:55 -0400] "GET /y.js?s=1&q=perl%20jobs%20in%20san%20francisco&l=us-en HTTP/1.1" 200 0 "http://0.0.0.0:5000/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.76 Safari/537.36"
127.0.0.1 - - [07/Oct/2013:03:48:56 -0400] "GET /y.js?x=1&q=perl%20jobs%20in%20san%20francisco&l=us-en&safe=1 HTTP/1.1" 200 0 "http://0.0.0.0:5000/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.76 Safari/537.36"
127.0.0.1 - - [07/Oct/2013:03:48:56 -0400] "GET /?duckduckhack_ignore=1&q=perl%20jobs%20in%20san%20francisco HTTP/1.1" 200 0 "http://0.0.0.0:5000/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.76 Safari/537.36"
```

Whatever the reason for that, `Web.pm` is not properly checking that a query is placed against the proper resource `/`. This additional check avoids the duplicated processing, and with it, prevents the confusingly repeated `Data::Printer` output.

Resolves issue https://github.com/duckduckgo/p5-app-duckpan/issues/17.
