### PR TITLE
send If-Modified-Since headers w/ update check

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -66,6 +66,7 @@ version = 0.96
 Starman = 0
 HTML::Parser = 3.71
 WWW::DuckDuckGo = 0.015
+POSIX = 1.32
 
 [Prereqs / TestRequires]
 Test::More = 0.98

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -13,7 +13,7 @@ use IO::All -utf8;
 use LWP::Simple;
 use HTML::TreeBuilder;
 use Config::INI;
-use POSIX;
+use POSIX ();
 
 sub run {
 	my ( $self, @args ) = @_;
@@ -43,7 +43,7 @@ sub run {
 		copy(file(dist_dir('App-DuckPAN'), $file_name), $cache_file_path) unless -f $cache_file_path;
 		next unless defined $spice_files{$file_name}{'file_path'};
 
-        my $mtime = strftime("%a, %d %b %Y %H:%M:%S", gmtime((stat($cache_file_path))[9])) . ' GMT';
+        my $mtime = POSIX::strftime("%a, %d %b %Y %H:%M:%S", gmtime((stat($cache_file_path))[9])) . ' GMT';
 		my $path = $spice_files{$file_name}{'file_path'};
 		my $url = 'http://'.$hostname.''.$path;
         my $req = HTTP::Request->new(GET => $url);


### PR DESCRIPTION
DuckPAN startup is painfully slow, mostly thanks to the numerous HTTP
requests it makes. This change (judging by an entirely unscientific
test) shaves off about 4 seconds from the start. It does so by sending
If-Modified-Since headers with the HTML/JS update checks, based of the
last modified time of the files in cache and checking for an HTTP 304
Not Modified status in the response.

```
duckpan server  0.90s user 0.03s system 11% cpu 7.967 total
duckpan -I../p5-app-duckpan/lib server  0.82s user 0.05s system 24% cpu 3.578 total
```

Another possibility is to use ETags to do data validation (which NGiNX
is sending), but would be trickier to implement with little gain.

This changeset depends on an internal PR - do not merge before it is
merged.
