### PR TITLE
Allow user to configure if queries will be shown in colours

### DIFF
--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -8,13 +8,11 @@ my $history_path;
 use Env qw( DP_NOCOLOR);
 # By setting the environment variable DP_NOCOLOR or ANSI_COLORS_DISABLED
 # change the behaviour of query printer on console. 
-if ($DP_NOCOLOR)
-{
+if ($DP_NOCOLOR) {
     require Data::Printer;
     import Data::Printer colored => 0;
 }
-else
-{
+else {
     require Data::Printer;
     import Data::Printer;
 }

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -10,13 +10,25 @@ use Plack::Response;
 use HTML::Entities;
 use HTML::TreeBuilder;
 use HTML::Element;
-use Data::Printer;
 use IO::All -utf8;
 use HTTP::Request;
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
 use Data::Dumper;
+
+use Env qw( DP_NOCOLOR);
+# By setting the environment variable DP_NOCOLOR or ANSI_COLORS_DISABLED
+# change the behaviour of query printer on console. 
+if ($DP_NOCOLOR) {
+    require Data::Printer;
+    import Data::Printer colored => 0;
+}
+else {
+    require Data::Printer;
+    import Data::Printer;
+}
+
 
 has blocks => ( is => 'ro', required => 1 );
 has page_root => ( is => 'ro', required => 1 );


### PR DESCRIPTION
Setting environment variable DP_NOCOLOR or ANSI_COLORS_DISABLED to show no colors with duckpan query command. Issue #29
