### PR TITLE
Zaahir/more utf8 fixes

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -12,7 +12,7 @@ use HTML::Entities;
 use HTML::TreeBuilder;
 use HTML::Element;
 use Data::Printer;
-use IO::All -utf8;
+use IO::All;
 use HTTP::Request;
 use LWP::UserAgent;
 use URI::Escape;


### PR DESCRIPTION
/cc @yegg @russellholt @nospampleasemam 

Whenever Quixey is used in DuckPAN (or whenever images are requested from the `/share` dir) IO:All has been throwing errors as it has been trying to UTF8 encode the contents of the file.

Removing the UTF8 flag naively solves this problem. After some testing, it seems that this flag may have not been entirely necessary.

To verify I put a bunch of UTF8 characters into one of the CSS files being served and everything worked fine.

I've also added a small fix to now properly pass along content-types to the response for files coming from the `/share`.

Let me know what you guys think :)
