### PR TITLE
add --no-cache and --verbose

### DIFF
--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -183,7 +183,6 @@ sub change_js {
 	my ( $self, $js ) = @_;
 	$js =~ s!/([ds])\.js\?!/?duckduckhack_ignore=1&!g;
 	$js =~ s!/post\.html!/?duckduckhack_ignore=1&!g;
-	$js =~ s!/post\.html!/?duckduckhack_ignore=1&!g;
 	return $self->change_css($js);
 }
 


### PR DESCRIPTION
/cc @yegg @russellholt @nospampleasemam 

Now that caching has been introduced, it's reasonable that we should have a way to force the requests for all the files, so I've added a `--no-cache` flag which prevents the cache from being used.

Also, in testing it was difficult to see what was going on, so I've added a `--verbose` flag to provide useful output.
