### PR TITLE
add protect_args flag to MooX::Options import

### DIFF
--- a/lib/App/DuckPAN/Cmd/Check.pm
+++ b/lib/App/DuckPAN/Cmd/Check.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Check;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 
 sub run {
 	my ( $self ) = @_;

--- a/lib/App/DuckPAN/Cmd/Goodie.pm
+++ b/lib/App/DuckPAN/Cmd/Goodie.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Goodie;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 use Module::Pluggable::Object;
 use Class::Load ':all';
 use Data::Printer;

--- a/lib/App/DuckPAN/Cmd/Install.pm
+++ b/lib/App/DuckPAN/Cmd/Install.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Install;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 
 sub run {
 	my ( $self, @args ) = @_;

--- a/lib/App/DuckPAN/Cmd/Installdeps.pm
+++ b/lib/App/DuckPAN/Cmd/Installdeps.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Installdeps;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 
 sub run {
 	my ( $self, @args ) = @_;

--- a/lib/App/DuckPAN/Cmd/Poupload.pm
+++ b/lib/App/DuckPAN/Cmd/Poupload.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Poupload;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 use HTTP::Request::Common qw(POST);
 use LWP::UserAgent;
 use Path::Class;

--- a/lib/App/DuckPAN/Cmd/Publisher.pm
+++ b/lib/App/DuckPAN/Cmd/Publisher.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Publisher;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 
 use Path::Class;
 use Plack::Handler::Starman;

--- a/lib/App/DuckPAN/Cmd/Query.pm
+++ b/lib/App/DuckPAN/Cmd/Query.pm
@@ -1,7 +1,8 @@
 package App::DuckPAN::Cmd::Query;
 # ABSTRACT: Command line tool for testing queries and see triggered plugins
 
-use MooX qw( Options );
+use MooX;
+use MooX::Options protect_argv => 0;
 with qw( App::DuckPAN::Cmd );
 
 sub run {

--- a/lib/App/DuckPAN/Cmd/Release.pm
+++ b/lib/App/DuckPAN/Cmd/Release.pm
@@ -1,7 +1,8 @@
 package App::DuckPAN::Cmd::Release;
 # ABSTRACT: Release the distribution of the current directory
 
-use MooX qw( Options );
+use MooX;
+use MooX::Options protect_argv => 0;
 with qw( App::DuckPAN::Cmd );
 
 sub run {

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Server;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 use Plack::Runner;
 use File::ShareDir::ProjectDistDir;
 use File::Copy;

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -1,7 +1,8 @@
 package App::DuckPAN::Cmd::Test;
 # ABSTRACT: Command for running the tests of this library
 
-use MooX qw( Options );
+use MooX;
+use MooX::Options protect_argv => 0;
 with qw( App::DuckPAN::Cmd );
 
 sub run {


### PR DESCRIPTION
This ensures that any flags or commands recognized are removed from @args when passed along to other handlers.
