### PR TITLE
Adding Vagrant option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Once you have installed the virtual machine you should be able to startup the VM
 
 ## Vagrant Virtual Environment
 
-The Vagrant-based DuckDuckHack virtual environment provides a similar sandbox to the DuckDuckHack VM, but rather than downloading a prebuilt VM, Vagrant creates an environment for you based on the defined configuration.  Vagrant is an awesome tool for building development environments.  One command - `vagrant up` - gets you a complete working environment in minutes.  Something go wrong with the environment?  No messing around with snapshots.  Tear the VM down and build a fresh environment.  The DuckDuckHack Vagrant environment uses on Chef cookbooks and the DuckPAN installer script, so configuration is transparent and easily shared.
+The Vagrant-based DuckDuckHack virtual environment provides a similar sandbox to the DuckDuckHack VM, but rather than downloading a prebuilt VM, Vagrant creates an environment for you based on the defined configuration.  Vagrant is an awesome tool for building development environments.  One command - `vagrant up` - gets you a complete working environment in minutes.  Something go wrong with the environment?  No messing around with snapshots.  Tear the VM down and build a fresh environment.  The DuckDuckHack Vagrant environment uses Chef cookbooks and the DuckPAN installer script, so configuration is transparent and easily shared.
 
 Through the Vagrant configuration, you can easily switch back and forth between a headless-mode and the traditional VirtualBox interface.  The configuration defaults to headless.
 


### PR DESCRIPTION
We've cleaned up the Vagrant implementation of DuckPAN a bit - this should now be ready for others to use.

No issues have been reported in the [forums](https://duck.co/forum/thread/4775/duckpan-with-vagrant) and this implementation is working well for us.

I've added a description of how to get up and running with the Vagrant-based environment to the README + a brief primer on the main Vagrant commands.  This addition also checks two items off of the DuckPAN roadmap, so I've updated that, as well.
