### PR TITLE
Catch and exit on SIGQUIT

### DIFF
--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -90,9 +90,11 @@ sub handle_user_input {
 }
  
 sub setup_console {
-  $_[HEAP]{console} = POE::Wheel::ReadLine->new(
+  my $powh_readline = POE::Wheel::ReadLine->new(
     InputEvent => 'got_user_input'
   );
+  $powh_readline->bind_key("C-\\", "interrupt");
+  $_[HEAP]{console} = $powh_readline;
   $_[HEAP]{console}->read_history($history_path);
   $_[HEAP]{console}->get("Query: ");
 }


### PR DESCRIPTION
This is expected behavior. Also submitted a POE::Wheel::Readline bug to
allow handling  of other generally expected signals:

https://rt.cpan.org/Public/Bug/Display.html?id=91615
