### PR TITLE
better error handling during block loading

### DIFF
--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -50,7 +50,15 @@ sub get_blocks_from_current_dir {
 	lib->import('lib');
 	print "\nUsing the following DDG instant answers:\n\n";
 	for (@args) {
-		load_class($_);
+		eval { load_class($_); };
+		if ($@) {
+			if ($@ =~ m|^Can't locate .+\.pm in \@INC|) {
+				print "Missing dependencies for $_.\n";
+				print "Try running `duckpan installdeps`.\n";
+				print "Is ./dist.ini up to date?\n";
+				exit 1;
+			} else { die $@; }
+		}
 		print " - ".$_;
 		print " (".$_->triggers_block_type.")\n";
 	}


### PR DESCRIPTION
Now prints out a helpful message when we can detect the error (missing
dependency module). Ideally this should just do the recommended action
(installdeps) itself, but I haven't quite figured out the structure for
that yet. This is an improvement regardless imho.

See issue https://github.com/duckduckgo/p5-app-duckpan/issues/55
