### PR TITLE
allow update to upgrade

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -171,7 +171,7 @@ sub execute {
 				$_ =~ /^ddg/i ||
 				$_ =~ /^app/i) {
 				push @modules, $_;
-			} elsif (lc $_ =~ m/duckpan|upgrade|update/) {
+			} elsif ($_ =~ m/^(duckpan|upgrade|update)$/i) {
 				push @modules, 'App::DuckPAN';
 				push @modules, 'DDG' if lc($_) eq 'upgrade';
 			} else {


### PR DESCRIPTION
Just a minor thing, but I found myself typing this in and was confused for a second to have the man page come up in less. This fixes that.

I'm not sure about the default "unrecognized command" behavior in general though. It brings up the manual page inside `$PAGER`. It'd be nice to have some sort of a notification that what you typed was incorrect for typos and the like. I also am not a fan of using a pager by default, but I can see how that might be helpful for newer users.
