### PR TITLE
Display "Answer" tab for Goodies in DP Server

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -303,6 +303,7 @@ sub request {
 
 				my $duckbar_home = $root->look_down(id => "duckbar_home");
 				$duckbar_home->delete_content();
+				$duckbar_home->attr(class => "zcm__menu");
 				$duckbar_home->push_content(
 					HTML::TreeBuilder->new_from_content(
 						q(<li class="zcm__item">


### PR DESCRIPTION
This forces an "Answer" tab to display for Goodies results when using duckpan server. 

The #duckbar_home div currently has a class of "zcm__dynamic" which defaults to `display: none`. The below fix removes that class by overwriting it with only "zcm__menu".

I'm not sure if there's a better way of doing this with JS? We could use jQuery to remove the class...

//cc @russellholt 
