### PR TITLE
pin versions for module installations

### DIFF
--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -78,14 +78,14 @@ sub duckpan_install {
 			my $module = $packages->package($_);
 			if ($module) {
 				local $@;
-                
-                # see if we have an env variable for this module
+				
+				# see if we have an env variable for this module
 				my $sp = $_;
 				$sp =~ s/\:\:/_/g;
 
-						# special case: check for a pinned verison number
+				# special case: check for a pinned verison number
 				my $pin_version = $ENV{$sp};
-						my $localver = $self->get_local_version($_);
+				my $localver = $self->get_local_version($_);
 				my $duckpan_module_version = version->parse($module->version);
 				my $duckpan_module_url = $self->app->duckpan.'authors/id/'.$module->distribution->pathname;
 


### PR DESCRIPTION
For each module to install, this change will check for a corresponding environment variable that will hold the max version number allowed to be installed.

for `DDG::SpiceBundle::OpenSourceDuckDuckGo`, it would check for `DDG_SpiceBundle_OpenSourceDuckDuckGo`.

This value will hold the max version number to install. It will only install this version if it is greater than the one currently installed.

It is possible that we could specify this on the command line, like `duckpan module@version` but this is slightly different that specifying a version number to install. Or is it?

@yegg @nilnilnil 
