### PR TITLE
DuckPAN Server - Add support for <svg>, <canvas>, etc

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -292,11 +292,14 @@ sub request {
 				my $zci_body = $zci_container->look_down(class => 'zci__body');
 
 				# Stick the answer inside $zci_body
-				$zci_body->push_content(
-					$result->has_html ?
-						HTML::TreeBuilder->new_from_content($result->html)->guts :
-						$result->answer
-				);
+				my $answer = $result->answer;
+				if ($result->has_html) {
+					my $tb = HTML::TreeBuilder->new();
+					# Specifically allow unknown tags to support <svg> and <canvas>
+					$tb->ignore_unknown(0);
+					$answer = $tb->parse_content($result->html)->guts;
+				}
+				$zci_body->push_content($answer);
 
 				my $zci_wrapper = $root->look_down(id => "zero_click_wrapper");
 				$zci_wrapper->insert_element($zci_container);


### PR DESCRIPTION
Previously HTML::Treebuilder was throwing away `<svg>` and `<canvas>` elements as they aren't part of the known HTML Tagset.

I've turned on the flag to allow "unknown_elements" which causes the parser to keep these unknown elements rather than throw it away.

This is in regards to a recent Goodie Pull Request: https://github.com/duckduckgo/zeroclickinfo-goodies/pull/464#issuecomment-47450394

//cc @russellholt @jagtalon 
