### PR TITLE
Force Duckpan to manually call Spice callback after templates are compiled

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -269,7 +269,8 @@ sub request {
 					} elsif ($_->filename =~ /^.+handlebars$/){
 						my $template_name = $_->filename;
 						$template_name =~ s/\.handlebars//;
-						$calls_template{$spice_name}{$template_name} = $_;
+						$calls_template{$spice_name}{$template_name}{"content"} = $_;
+						$calls_template{$spice_name}{$template_name}{"is_ct_self"} = $result->call_type eq 'self';
 					}
 				}
 				push (@calls_nrj, $result->call_path);
@@ -343,12 +344,12 @@ sub request {
 			: '';
 
 		if (%calls_template) {
-
 			foreach my $spice_name ( keys %calls_template ){
 				$calls_script .= join("",map {
 					my $template_name = $_;
-					my $template_content = $calls_template{$spice_name}{$template_name}->slurp;
-					"<script class='duckduckhack_spice_template' spice-name='$spice_name' template-name='$template_name' type='text/plain'>$template_content</script>"
+					my $is_ct_self = $calls_template{$spice_name}{$template_name}{"is_ct_self"};
+					my $template_content = $calls_template{$spice_name}{$template_name}{"content"}->slurp;
+					"<script class='duckduckhack_spice_template' spice-name='$spice_name' template-name='$template_name' is-ct-self='$is_ct_self' type='text/plain'>$template_content</script>"
 
 				} keys $calls_template{$spice_name});
 			}

--- a/share/duckpan.js
+++ b/share/duckpan.js
@@ -5,7 +5,8 @@ $(document).ready(function() {
 	DDG.duckpan = true;
 
 	// array of spice template <script>
-	var hb_templates = $("script.duckduckhack_spice_template");
+	var hb_templates = $("script.duckduckhack_spice_template"),
+		toCall = [];
 
 	// Check for any spice templates
 	// grab their contents and name
@@ -18,6 +19,9 @@ $(document).ready(function() {
 			content = $script.html();
 			spiceName = $script.attr("spice-name");
 			templateName = $script.attr("template-name");
+			if ($script.attr("is-ct-self") === "1"){
+				toCall.push(spiceName);
+			}
 
 			if (!Spice.hasOwnProperty(spiceName)) {
 				Spice[spiceName] = {};
@@ -30,6 +34,17 @@ $(document).ready(function() {
 
 		console.log("Finished compiling templates")
 		console.log("Now Spice obj: ", Spice);
+
+		// Need to wait a little for page JS to finish
+		// modifying the DOM
+		setTimeout(function(){
+			$.each(toCall, function(i, name){
+				var cbName = "ddg_spice_" + name;
+				console.log("Executing: " + cbName);
+				window[cbName]();
+			});
+		}, 100);
+
 		return;
 	}
 });


### PR DESCRIPTION
//cc @russellholt @jagtalon 

This should be a _temporary_ fix is regards to https://github.com/duckduckgo/zeroclickinfo-spice/issues/914

It seems that the current problem with Spices which have `call_type => 'self'` is that they're triggering a little too fast for DuckPAN because their callback functions are executed immediately after they are defined in their JS files.

This fix allows DuckPAN to tell the frontend if it needs to manually call the callback after the templates are compiled. You'll still see an error in the console from the first failed call which comes from the JS file. Right now I can't think of a better fix, but I'm open to suggestions!
