### PR TITLE
Check $localver is defined in earlier if statement to prevent undef error

### DIFF
--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -94,9 +94,9 @@ sub duckpan_install {
 				my $duckpan_module_version = version->parse($module->version);
 				my $duckpan_module_url = $self->app->duckpan.'authors/id/'.$module->distribution->pathname;
 
-				if ($pin_version) {
+				if ($pin_version && $localver) {
 					print "$_: $localver installed, $pin_version pin, $duckpan_module_version latest\n";
-					if ($localver && $pin_version > $localver && $duckpan_module_version > $localver && $duckpan_module_version <= $pin_version) {
+					if ($pin_version > $localver && $duckpan_module_version > $localver && $duckpan_module_version <= $pin_version) {
 						push @to_install, $duckpan_module_url unless grep { $_ eq $duckpan_module_url } @to_install;
 					}
 				} elsif ($localver && $localver == $duckpan_module_version) {


### PR DESCRIPTION
Currently, line 98 (https://github.com/duckduckgo/p5-app-duckpan/blob/master/lib/App/DuckPAN/Perl.pm#L98) assumes `$localver` is defined, I've moved the check for `$localver` in the next line to the preceeding line
//cc @russellholt @malbin 
