### PR TITLE
Web.pm - Make sure we only inject one Goodie result into the detail area

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -320,7 +320,10 @@ sub request {
 				$duckbar_static_sep->attr(class => "zcm__sep--h");
 
 				my $html = $root->look_down(_tag => "html");
-				$html->attr(class => "set-header--fixed  has-zcm js no-touch csstransforms3d csstransitions svg use-opts has-active-zci")
+				$html->attr(class => "set-header--fixed  has-zcm js no-touch csstransforms3d csstransitions svg use-opts has-active-zci");
+
+				# Make sure we only show one Goodie (this will change down the road)
+				last;
 
 			# If not Spice or Goodie,
 			# inject raw Dumper() output from into page


### PR DESCRIPTION
Fixes #97 

Before:
![image](https://cloud.githubusercontent.com/assets/873785/3857303/f58e26e0-1f01-11e4-8c01-b06074aa23d2.png)

After:
![2014-08-08_09h43_39](https://cloud.githubusercontent.com/assets/873785/3857314/07063dfe-1f02-11e4-911b-9b10f4a2bdeb.png)

cc// @jagtalon @russellholt 
