### PR TITLE
Add port option to duckpan server to allow port specification

### DIFF
--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -29,6 +29,14 @@ option verbose => (
     default => sub { 0 }
 );
 
+option port => (
+    is => 'ro',
+    format => 'i',
+    lazy => 1,
+    short => 'p',
+    default => sub { 5000 }
+);
+
 has page_js_filename => (
     is => 'rw',
 );
@@ -178,6 +186,7 @@ sub run {
         app => sub { $web->run_psgi(@_) },
     );
     #$runner->loader->watch("./lib");
+    $runner->parse_options("--port", $self->port);
     exit $runner->run;
 }
 


### PR DESCRIPTION
A dev asked on the community platform if it was possible to specify a different port for the DuckPAN Server. It wasn't, but I figured that was a reasonable request so I've added in that functionality,

cc// @jagtalon @russellholt @mwmiller @jdorweiler 

You can now specify a port using `duckpan server --port 1234` or `-p 1234` or `--port=1234`

Picture of it working:
![2014-08-21_16h12_51](https://cloud.githubusercontent.com/assets/873785/4002740/bb25ff6e-296f-11e4-847a-bd42ca85b937.png)
