### PR TITLE
Make `duckpan setup` work properly.

### DIFF
--- a/lib/App/DuckPAN/Cmd/Setup.pm
+++ b/lib/App/DuckPAN/Cmd/Setup.pm
@@ -49,7 +49,7 @@ sub get_email { shift->app->get_reply( 'What is your email (public in your relea
 
 sub run {
 	my ( $self ) = @_;
-	exit if $self->app->check_requirements != 0
+	exit if $self->app->check_requirements != 0;
 	if (my $dzil_config = $self->app->perl->get_dzil_config) {
 		print "\nFound existing Dist::Zilla config!\n\n";
 		my $name = $dzil_config->{'%User'}->{name};


### PR DESCRIPTION
- Changed 'unless' to 'if' because `check_requirements` returns `0` for success

Not entirely sure if `check_requirements` should return a `0` for success (it seems `exit` indicates success with 0 though) - but reversing this check was easier than reversing the logic and all other checks in DuckPAN.

//cc @jagtalon @mwmiller 
