### PR TITLE
Highlight request failed message

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -164,7 +164,7 @@ sub request {
 						$response->code($res->code);
 						$response->content_type($res->content_type);
 					} else {
-						warn $res->status_line, "\n";
+						p($res->status_line, color => { string => 'red' });
 						$body = "";
 					}
 				}


### PR DESCRIPTION
fixes #89 
I feel there should be an indication through the page also, because, i think that, new users would be more susceptible to miss out on the terminal output, as they'd be more focused on the frontend side. 
I highlighted the request failed message, so that it captures attention, doesnt completely solve our issue, but should be good. I have a really neat idea on improving duckpan, give me some time, ill handle this in it as well.
