### PR TITLE
remove slurp_utf8 and spew_utf8

### DIFF
--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -135,23 +135,25 @@ sub run {
     }
 
     # Pull files out of cache to be served later by DuckPAN server
-    my $page_root  = $cache_path->child('page_root.html')->slurp_utf8;
-    my $page_spice = $cache_path->child('page_spice.html')->slurp_utf8;
+    my $page_root  = $cache_path->child('page_root.html')->slurp;
+    my $page_spice = $cache_path->child('page_spice.html')->slurp;
 
     # Since there are multiple CSS files to slurp in,
     # we iterate through each one.
-    my $page_css = join('', map { $cache_path->child($_->{internal})->slurp_utf8 } @{$self->page_css_files_list});
-    my $page_js = $cache_path->child($self->page_js_files->{internal})->slurp_utf8;
-    my $page_locales = $cache_path->child($self->page_locales_files->{internal})->slurp_utf8;
+    my $page_css = join('', map { $cache_path->child($_->{internal})->slurp } @{$self->page_css_files_list});
+    my $page_js = $cache_path->child($self->page_js_files->{internal})->slurp;
+    my $page_locales = $cache_path->child($self->page_locales_files->{internal})->slurp;
     # Concatenate duckpan.js to g.js
     # This way duckpan.js runs after all dependencies are loaded
-    my $page_templates = $cache_path->child($self->page_templates_files->{internal})->slurp_utf8;
+    my $page_templates = $cache_path->child($self->page_templates_files->{internal})->slurp;
     $page_templates .= "\n//duckpan.js\n";
-    $page_templates .= $cache_path->child('duckpan.js')->slurp_utf8;
+    $page_templates .= $cache_path->child('duckpan.js')->slurp;
 
     print "\n\nStarting up webserver...";
     print "\n\nYou can stop the webserver with Ctrl-C";
     print "\n\n";
+
+    warn "\n\nMODIFIED DEVELOPMENT VERSION OF DUCKPAN\n\n";
 
     require App::DuckPAN::Web;
 
@@ -376,7 +378,7 @@ sub retrieve_and_cache {
         my $change_method = ($file_name =~ m/\.js$/) ? 'change_js' : ($file_name =~ m/\.css$/) ? 'change_css' : 'change_html';
         # Put rewriten file into our cache.
         my $where = path($self->app->cfg->cache_path, $file_name);
-        $where->spew_utf8($self->$change_method($content));
+        $where->spew($self->$change_method($content));
         print $prefix. "written to cache: $where\n" if $self->verbose;
     } else {
         print "failed!\n" if $self->verbose;

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -103,14 +103,14 @@ sub request {
 			my $parent_name = $2;
 			my $common_js = $parent_dir."$parent_name.js";
 
-			$body = path($common_js)->slurp_utf8;
+			$body = path($common_js)->slurp;
 			warn "\nAppended $common_js to $filename\n\n";
 		}
 
 		my $filename_path = $self->_share_dir_hash->{$share_dir}->can('share')->($filename);
 		my $content_type = Plack::MIME->mime_type($filename);
 		$response->content_type($content_type);
-		$body .= -f $filename_path ? path($filename_path)->slurp_utf8 : "";
+		$body .= -f $filename_path ? path($filename_path)->slurp : "";
 
 	} elsif (@path_parts && $path_parts[0] eq 'js' && $path_parts[1] eq 'spice') {
 		for (keys %{$self->_path_hash}) {
@@ -360,7 +360,7 @@ sub request {
 				$calls_script .= join("",map {
 					my $template_name = $_;
 					my $is_ct_self = $calls_template{$spice_name}{$template_name}{"is_ct_self"};
-					my $template_content = $calls_template{$spice_name}{$template_name}{"content"}->slurp_utf8;
+					my $template_content = $calls_template{$spice_name}{$template_name}{"content"}->slurp;
 					"<script class='duckduckhack_spice_template' spice-name='$spice_name' template-name='$template_name' is-ct-self='$is_ct_self' type='text/plain'>$template_content</script>"
 
 				} keys %{ $calls_template{$spice_name} });


### PR DESCRIPTION
cc// @mwmiller 

@jagtalon noticed that for some queries DuckPAN was failing, complaining about UTF8. I tried removing the utf8 slurp and spew and it seemed to solve the problem.

I have no idea why it fixed it though, which worries me.

Merging as a hotfix
