### PR TITLE
change --no-cache to --force, fix implementation

### DIFF
--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -242,7 +242,7 @@ sub change_html {
     my $has_dpanjs = 0;
     for (@script) {
         if (my $src = $_->attr('src')) {
-            next if ($src =~ m/^\/\?duckduckhack_/);    # Already updated, no need to do again
+            next if ($src =~ m/^\/\?duckduckhack_/); # Already updated, no need to do again
             if ($src =~ m/^\/(dpan\d+|duckpan_dev)\.js/) {
                 $_->attr('src','/?duckduckhack_js=1');
                 $has_dpanjs = 1;


### PR DESCRIPTION
//cc @mwmiller 

I just noticed that there was a small bug in the `--no-cache` implementation, which lead me to believe the purpose of the command wasn't easily understood by its name. I've changed it to `--force` because that's what it really does; It **forces** DuckPAN to ignore any cached files, and requests everything it needs.

Would like to merge relatively soon because it's technically broken, but really none one other than DDG Staff has much need for the command and you can work around it by manually clearing the cache.
