### PR TITLE
duckpan: fail on missing include directory.

### DIFF
--- a/bin/duckpan
+++ b/bin/duckpan
@@ -6,12 +6,14 @@ my @libs;
 
 BEGIN {
     use Getopt::Long qw/:config bundling pass_through/;
+    use Path::Tiny;
+    use Try::Tiny;
     GetOptions 'include|I=s' => \@libs;
     @libs = split ',', join ',', @libs;
-    use Path::Tiny;
     if (my @missing = grep { !$_->exists } map { path($_) } @libs) {
         my $plural = (scalar @missing == 1) ? '' : 's';
-        print '[FATAL ERROR] Missing include path' . $plural . ': ' . join(', ', map { $_->realpath } @missing) . "\n";
+        print '[FATAL ERROR] Missing include path' . $plural . ': ' . join(', ',
+            map { try { $_->realpath } || $_->absolute } @missing) . "\n";
         exit 1;
     }
 }

--- a/dist.ini
+++ b/dist.ini
@@ -69,6 +69,7 @@ URI = 1.60
 version = 0.96
 Starman = 0.4008
 Text::Xslate = 3.0.0
+Try::Tiny = 0.22
 HTML::Parser = 3.71
 WWW::DuckDuckGo = 0.015
 

--- a/t/system_duckpan.t
+++ b/t/system_duckpan.t
@@ -10,50 +10,47 @@ use App::DuckPAN;
 
 my $version = $App::DuckPAN::VERSION;
 
-{
-	my ( $return, $out, $err ) = run_script( 'duckpan', [] );
+subtest 'no arguments' => sub {
+	my ($return, $out, $err) = run_script('duckpan', []);
 
-	like($out,qr/DuckPAN/, 'DuckPAN without arguments gives out usage');
-	# like($out,qr/$version/, 'DuckPAN man page gives out right version');
+	like($out, qr/DuckPAN/, 'DuckPAN without arguments gives out usage');
+	is($return, 1, 'DuckPAN gives back exit code 1');
+};
 
-	# 2014-10-20 Zaahir
-	# Removing this test because it seems unnecesary
-	# and it causes problems for systems with old versions
-	# of Groff
-	# is($err,"",'DuckPAN gives out nothing on STDERR');
-	is($return,1,'DuckPAN gives back exit code 1');
-}
-
-{
+subtest 'bad include paths' => sub {
 	my $fake_dir = 'fake-directory';
 	my ($return, $out, $err) = run_script('duckpan', ['-I' . $fake_dir]);
 
 	ok($return, 'DuckPAN with non-existent include path exits with an error');
 	like($out, qr/Missing include path.*$fake_dir/, ' after printing a message showing the bad path');
-}
 
+	$fake_dir = '../fake-directory/even-faker';
+	($return, $out, $err) = run_script('duckpan', ['-I' . $fake_dir]);
+	ok($return, 'DuckPAN with non-existent multi-way include path exits with an error');
+	like($out, qr/Missing include path.*$fake_dir/, ' after printing a message showing the bad path');
+};
 
-{
+subtest 'env' => sub {
 	my $tempdir = Path::Tiny->tempdir(CLEANUP => 1);
 	$ENV{DUCKPAN_CONFIG_PATH} = "$tempdir";
 
-	run_ok( 'duckpan', [qw( env test me )], 'setting DuckPAN env test to me');
+	run_ok('duckpan', [qw( env test me )], 'setting DuckPAN env test to me');
 
-	is($tempdir->child('env.ini')->slurp,"TEST = me\n",'checking content of env.ini');
+	is($tempdir->child('env.ini')->slurp, "TEST = me\n", 'checking content of env.ini');
 
-	my ( undef, $getenvout, $getenverr ) = run_script( 'duckpan', [qw( env test )]);
+	my (undef, $getenvout, $getenverr) = run_script('duckpan', [qw( env test )]);
 
-	like($getenvout,qr/TEST='me'/,'getting test env from DuckPAN');
-	is($getenverr,'','no error output on test env from DuckPAN');
+	like($getenvout, qr/TEST='me'/, 'getting test env from DuckPAN');
+	is($getenverr, '', 'no error output on test env from DuckPAN');
 
-	run_ok( 'duckpan', [qw( rm test )], 'removing DuckPAN env test to me');
+	run_ok('duckpan', [qw( rm test )], 'removing DuckPAN env test to me');
 
-	is($tempdir->child('env.ini')->slurp,"",'checking content of env.ini');
+	is($tempdir->child('env.ini')->slurp, "", 'checking content of env.ini');
 
-	( undef, $getenvout, $getenverr ) = run_script( 'duckpan', [qw( env test )]);
+	(undef, $getenvout, $getenverr) = run_script('duckpan', [qw( env test )]);
 
-	like($getenvout,qr/TEST is not set/,'getting test env from DuckPAN after removing it');
-	is($getenverr,'','no error output on test env from DuckPAN after removing it');
-}
+	like($getenvout, qr/TEST is not set/, 'getting test env from DuckPAN after removing it');
+	is($getenverr, '', 'no error output on test env from DuckPAN after removing it');
+};
 
 done_testing;


### PR DESCRIPTION
Using realpath instead of user-entered string, in order to possibly help
them spot the problem.

Addresses #156.
