### PR TITLE
Don't be so quick to throw the manpage in my face

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -243,7 +243,6 @@ sub execute {
 		exit $self->perl->duckpan_install(@modules) unless @left_args;
 	}
 	$self->exit_with_msg(-1, "Unknown command. Use `duckpan help` to see the list of available DuckPAN commands.");
-	exit 0;
 }
 
 sub print_text {


### PR DESCRIPTION
This has bugged me for a long time...

@mwmiller @killerfish any thoughts on this?

Here's the updated output:

```
[09:13 PM codio@teresa-misted duckpan {zaahir/calm-down-duckpan}]$ duckpan garbage                                                                                            

[ERROR] Unknown command. Use `duckpan help` to see the list of available DuckPAN commands.
```

---

I also noticed that because we're using `MooX::Options`, it auto generates a list of commands and arguments for each possible command (thanks to `GetOpt::Long`). If we went through and documented each command and all the arguments that could be a little nicer than showing the manpage because then at least I don't have to exit something to get back to my commandline.

```
[09:10 PM codio@teresa-misted duckpan {zaahir/calm-down-duckpan}]$ duckpan --help                                                                                             
USAGE: duckpan [-h] [long options...]                                                                                                                                         

    --cache:                                                                                                                                                                  
        no doc for cache                                                                                                                                                      

    --config:                                                                                                                                                                 
        no doc for config                                                                                                                                                     

    --duckpan:                                                                                                                                                                
        no doc for duckpan                                                                                                                                                    

    --duckpan_packages:                                                                                                                                                       
        no doc for duckpan_packages                                                                                                                                           

    --dukgo_login:                                                                                                                                                            
        no doc for dukgo_login                                                                                                                                                

    --http_proxy:                                                                                                                                                             
        no doc for http_proxy                                                                                                                                                 

    --no_check:                                                                                                                                                               
        no doc for no_check                                                                                                                                                   

    --usage:                                                                                                                                                                  
        show a short help message                                                                                                                                             

    -h --help:                                                                                                                                                                
        show a help message                                                                                                                                                   

    --man:                                                                                                                                                                    
        show the manual


SUB COMMANDS AVAILABLE: check, env, goodie, install, installdeps, new, poupload, publisher, query, release, rm, roadrunner, server, setup, test                               
```

Sub-command:

```
[09:10 PM codio@teresa-misted duckpan {zaahir/calm-down-duckpan}]$ duckpan server --help                                                                                      
USAGE: duckpan [-cfhpv] [long options...]                                                                                                                                     

    -c --cachesec: Int                                                                                                                                                        
        no doc for cachesec                                                                                                                                                   

    -f --force:                                                                                                                                                               
        no doc for force                                                                                                                                                      

    -p --port: Int                                                                                                                                                            
        no doc for port                                                                                                                                                       

    -v --verbose:                                                                                                                                                             
        no doc for verbose                                                                                                                                                    

    --usage:                                                                                                                                                                  
        show a short help message                                                                                                                                             

    -h --help:                                                                                                                                                                
        show a help message                                                                                                                                                   

    --man:                                                                                                                                                                    
        show the manual
```
