### PR TITLE
Code Reload.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,9 +34,11 @@ tag_format = %v
 push_to = origin master
 
 [Prereqs]
+again = 0.08
 autodie = 2.25
 App::cpanminus = 1.7014
 Class::Load = 0.18
+Class::Unload = 0.08
 Config::INI = 0.019
 CPAN::Repository = 0.007
 Crypt::SSLeay = 0.58

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -524,7 +524,13 @@ sub checking_dukgo_user {
 	$response->code == 302 ? 1 : 0; # workaround, need something in dukgo
 }
 
-sub get_ia_type {
+has 'ia_type' => (
+	is      => 'ro',
+	lazy    => 1,
+	builder => 1,
+);
+
+sub _build_ia_type {
 	my ($self) = @_;
 
 	my $ia_type = first { $_->{dir}->is_dir } @{$self->ia_types};

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -389,9 +389,14 @@ sub check_requirements {
 		$self->emit_info("Checking for DuckPAN requirements...");
 
 		$self->emit_and_exit(1, 'Requirements check failed')
-		  unless ($self->check_perl && $self->check_app_duckpan && $self->check_ddg && $self->check_ssh && $self->check_git);
+		  unless ($self->check_app_duckpan
+			&& $self->check_perl
+			&& $self->check_ddg
+			&& $self->check_ssh
+			&& $self->check_git);
+
+		$signal_file->touch;
 	}
-	$signal_file->touch;
 
 	return 1;
 }

--- a/lib/App/DuckPAN/Cmd/New.pm
+++ b/lib/App/DuckPAN/Cmd/New.pm
@@ -20,7 +20,7 @@ sub run {
 	my ($self, @args) = @_;
 
 	# Check which IA repo we're in...
-	my $type = $self->app->get_ia_type();
+	my $type = $self->app->ia_type;
 
 	# Instant Answer name as parameter
 	my $entered_name = (@args) ? join(' ', @args) : $self->app->get_reply('Please enter a name for your Instant Answer');

--- a/lib/App/DuckPAN/Cmd/Query.pm
+++ b/lib/App/DuckPAN/Cmd/Query.pm
@@ -9,10 +9,10 @@ sub run {
 	my ($self, @args) = @_;
 
 	$self->app->check_requirements;    # Will exit if missing
-	my @blocks = @{$self->app->ddg->get_blocks_from_current_dir(@args)};
-
+	my $loader = $self->app->ddg->blocks_loader(@args);
+	$loader->();
 	require App::DuckPAN::Query;
-	exit App::DuckPAN::Query->run($self->app, @blocks);
+	exit App::DuckPAN::Query->run($self->app, $loader);
 }
 
 1;

--- a/lib/App/DuckPAN/Cmd/Query.pm
+++ b/lib/App/DuckPAN/Cmd/Query.pm
@@ -9,10 +9,10 @@ sub run {
 	my ($self, @args) = @_;
 
 	$self->app->check_requirements;    # Will exit if missing
-	my $loader = $self->app->ddg->blocks_loader(@args);
-	$loader->();
+	my $loader = $self->app->ddg->blocks_loading_function(@args);
+	my $blocks = $loader->();
 	require App::DuckPAN::Query;
-	exit App::DuckPAN::Query->run($self->app, $loader);
+	exit App::DuckPAN::Query->run($self->app, $loader, $blocks);
 }
 
 1;

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -99,8 +99,8 @@ sub run {
     $self->app->check_requirements; # Ensure eveything is up do date, or exit.
 
 
-    my $blocks_loader = $self->app->ddg->blocks_loader(@args);
-    $blocks_loader->();
+    my $blocks_loader = $self->app->ddg->blocks_loading_function(@args);
+    my $blocks = $blocks_loader->();
 
     $self->app->emit_debug("Hostname is: http://" . $self->hostname);
     $self->app->emit_info("Checking asset cache...");
@@ -118,6 +118,7 @@ sub run {
 
     # Pull files out of cache to be served later by DuckPAN server
     my %web_args = (
+        blocks          => $blocks,
         blocks_loader   => $blocks_loader,
         server_hostname => $self->hostname,
     );

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -99,7 +99,8 @@ sub run {
     $self->app->check_requirements; # Ensure eveything is up do date, or exit.
 
 
-    my @blocks = @{$self->app->ddg->get_blocks_from_current_dir(@args)};
+    my $blocks_loader = $self->app->ddg->blocks_loader(@args);
+    $blocks_loader->();
 
     $self->app->emit_debug("Hostname is: http://" . $self->hostname);
     $self->app->emit_info("Checking asset cache...");
@@ -117,7 +118,7 @@ sub run {
 
     # Pull files out of cache to be served later by DuckPAN server
     my %web_args = (
-        blocks          => \@blocks,
+        blocks_loader   => $blocks_loader,
         server_hostname => $self->hostname,
     );
     foreach my $page (keys %{$self->page_info}) {

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -38,7 +38,7 @@ sub get_blocks_from_current_dir {
     $self->emit_and_exit(1, 'You need to have the DDG distribution installed', 'To get the installation command, please run: duckpan check')
       unless ($self->app->get_local_ddg_version);
 
-    my $type   = $self->app->get_ia_type();
+    my $type   = $self->app->ia_type;
     my $finder = Module::Pluggable::Object->new(
         search_path => [$type->{dir}],
     );

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -3,11 +3,14 @@ package App::DuckPAN::DDG;
 
 use Moo;
 with 'App::DuckPAN::HasApp';
+use feature 'state';
 
+use again;
 use Module::Pluggable::Object;
-use Class::Load ':all';
+use Class::Unload;
 use Data::Printer;
 use List::Util qw (first);
+use Try::Tiny;
 
 sub get_dukgo_user_pass {
     my ($self) = @_;
@@ -32,95 +35,110 @@ sub show_failed_modules {
     }
 }
 
-sub get_blocks_from_current_dir {
-    my ($self, @args) = @_;
+has all_modules => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => 1,
+    clearer => 1,
+);
 
-    $self->emit_and_exit(1, 'You need to have the DDG distribution installed', 'To get the installation command, please run: duckpan check')
-      unless ($self->app->get_local_ddg_version);
+sub _build_all_modules {
+    my $self = shift;
 
     my $type   = $self->app->ia_type;
     my $finder = Module::Pluggable::Object->new(
         search_path => [$type->{dir}],
     );
-    if (scalar @args == 0) {
-        my @plugins = $finder->plugins;
-        push @args, sort { $a cmp $b } @plugins;
-        @args = map {
-            $_ =~ s!/!::!g;
-            my @parts = split('::', $_);
-            shift @parts;
-            join('::', @parts);
-        } @args;
-    } else {
-        @args = map { $_ = "DDG::" . $type->{name} . "::$_" unless m,^lib(::|/)DDG,; $_; } @args;
-    }
-    require lib;
-    lib->import('lib');
-    $self->app->emit_info("Loading Instant Answers...");
+    $self->app->emit_debug('Scanning ' . $type->{dir} . ' for available modules...');
+    my @plugins = map {
+        $_ =~ s!/!::!g;
+        my @parts = split('::', $_);
+        shift @parts;
+        join('::', @parts);
+      } sort {
+        $a cmp $b
+      } ($finder->plugins);
 
-    # This list contains all of the classes that loaded successfully.
-    my @successfully_loaded = ();
+    return \@plugins;
+}
 
-    # This hash contains all of the modules that failed.
-    # The key contains the module name and the value contains the dependency that wasn't met.
-    my %failed_to_load = ();
+sub blocks_loader {
+    my ($self, @args) = @_;
 
-    # This loop goes through each Goodie / Spice, and it tries to load it.
-    foreach my $class (@args) {
-        # Let's try to load each Goodie / Spice module
-        # and see if they load successfully.
-        my ($load_success, $load_error_message) = try_load_class($class);
-
-        # If they load successfully, $load_success would be a 1.
-        # Otherwise, it would be a 0.
-        if ($load_success) {
-            # Since we only want the successful classes to trigger, we
-            # collect all of the ones that triggered successfully in a temporary list.
-            push @successfully_loaded, $class;
-
-            # Display to the user when a class has been successfully loaded.
-            $self->app->emit_debug(" - $class (" . $class->triggers_block_type . ")");
-        } else {
-            # Get the module name that needs to be installed by the user.
-            if ($load_error_message =~ /Can't locate ([^\.]+).pm in \@INC/) {
-                $load_error_message = $1;
-                $load_error_message =~ s/\//::/g;
-
-                $failed_to_load{$class} = "Please install $load_error_message and any other required dependencies to use this instant answer.";
-            } else {
-                # We just set the value to whatever the error message was if it failed for some other reason.
-                $failed_to_load{$class} = $load_error_message;
+    return sub {
+        my $type = $self->app->ia_type;
+        my @mods;
+        if (@args == 0) {
+            state $dir_checked = $type->{dir}->stat->mtime;
+            if ((my $latest = $type->{dir}->stat->mtime) > $dir_checked) {
+                $self->clear_all_modules;
+                $dir_checked = $latest;
             }
+            @mods = @{$self->all_modules};
+        } else {
+            @mods = map { $_ = "DDG::" . $type->{name} . "::$_" unless m,^lib(::|/)DDG,; $_; } @args;
         }
-    }
 
-    # Since @args can contain modules that we don't want to trigger (since they didn't load in the first place),
-    # and @successfully_loaded does, we just use what's in @successfully_loaded.
-    @args = @successfully_loaded;
+        require lib;
+        lib->import('lib');
+        Class::Unload->unload('Moo'); # Otherwise it will not reapply constructors.
+        $self->app->emit_info("Loading Instant Answers...");
 
-    # Now let's tell the user why some of the modules failed.
-    $self->show_failed_modules(\%failed_to_load);
+        # This list contains all of the classes that loaded successfully.
+        my @successfully_loaded = ();
 
-    my %blocks_plugins;
-    for (@args) {
-        unless ($blocks_plugins{$_->triggers_block_type}) {
-            $blocks_plugins{$_->triggers_block_type} = [];
+        # This hash contains all of the modules that failed.
+        # The key contains the module name and the value contains the dependency that wasn't met.
+        my %failed_to_load = ();
+
+        # This loop goes through each Goodie / Spice, and it tries to load it.
+        foreach my $class (@mods) {
+            # Let's try to load each Goodie / Spice module
+            # and see if they load successfully.
+            try {
+                if (require_again($class)) {
+                    # We actually (re-)loaded the class.
+                    $self->app->emit_debug(" + $class (" . $class->triggers_block_type . ")");
+                }
+                # Regardless, it's loaded.
+                push @successfully_loaded, $class;
+            }
+            catch {
+                # Get the module name that needs to be installed by the user.
+                if ($_ =~ /Can't locate ([^\.]+).pm in \@INC/) {
+                    my $dep_error = $1;
+                    $dep_error =~ s/\//::/g;
+
+                    $failed_to_load{$class} = "Please install $dep_error and any other required dependencies to use this instant answer.";
+                } else {
+                    # We just set the value to whatever the error message was if it failed for some other reason.
+                    $failed_to_load{$class} = $_;
+                }
+            };
         }
-        push @{$blocks_plugins{$_->triggers_block_type}}, $_;
-    }
 
-    my @blocks;
-    for (keys %blocks_plugins) {
-        my $block_class = 'DDG::Block::' . $_;
-        load_class($block_class);
-        push @blocks,
-          $block_class->new(
-            plugins    => $blocks_plugins{$_},
-            return_one => 0
-          );
-    }
-    load_class('DDG::Request');
-    return \@blocks;
+        # Now let's tell the user why some of the modules failed.
+        $self->show_failed_modules(\%failed_to_load);
+
+        my %blocks_plugins;
+        for (@successfully_loaded) {
+            $blocks_plugins{$_->triggers_block_type} //= [];
+            push @{$blocks_plugins{$_->triggers_block_type}}, $_;
+        }
+
+        my @blocks;
+        for (keys %blocks_plugins) {
+            my $block_class = 'DDG::Block::' . $_;
+            require_again($block_class);
+            push @blocks,
+              $block_class->new(
+                plugins    => $blocks_plugins{$_},
+                return_one => 0
+              );
+        }
+        require_again('DDG::Request');
+        return \@blocks;
+    };
 }
 
 1;

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -61,11 +61,12 @@ sub _build_all_modules {
     return \@plugins;
 }
 
-sub blocks_loader {
+sub blocks_loading_function {
     my ($self, @args) = @_;
 
+    my $type = $self->app->ia_type;
+
     return sub {
-        my $type = $self->app->ia_type;
         my @mods;
         if (@args == 0) {
             state $dir_checked = $type->{dir}->stat->mtime;
@@ -118,6 +119,8 @@ sub blocks_loader {
                 }
             };
         }
+
+        return unless $changes;
 
         # Now let's tell the user why some of the modules failed.
         $self->show_failed_modules(\%failed_to_load, $dep_error);

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -10,7 +10,7 @@ use Data::Printer;
 use POE qw( Wheel::ReadLine );
 
 sub run {
-	my ( $self, $app, @blocks ) = @_;
+	my ( $self, $app, $blocks_loader ) = @_;
 
 	require DDG;
 	DDG->import;
@@ -44,7 +44,7 @@ sub run {
 				language => test_language_by_env(),
 			);
 			my $hit;
-			for my $b (@blocks) {
+			for my $b (@{$blocks_loader->()}) {
 				for ($b->request($request)) {
 					$hit = 1;
 					$app->emit_info('---', p($_, colored => $app->colors), '---');

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -10,7 +10,7 @@ use Data::Printer;
 use POE qw( Wheel::ReadLine );
 
 sub run {
-	my ( $self, $app, $blocks_loader ) = @_;
+	my ( $self, $app, $blocks_loader, $blocks ) = @_;
 
 	require DDG;
 	DDG->import;
@@ -44,7 +44,10 @@ sub run {
 				language => test_language_by_env(),
 			);
 			my $hit;
-			for my $b (@{$blocks_loader->()}) {
+			if (my $updated_blocks = $blocks_loader->()) {
+				$blocks = $updated_blocks;
+			}
+			for my $b (@$blocks) {
 				for ($b->request($request)) {
 					$hit = 1;
 					$app->emit_info('---', p($_, colored => $app->colors), '---');

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -19,7 +19,7 @@ use URI::Escape;
 use JSON;
 use Data::Dumper;
 
-has blocks => ( is => 'ro', required => 1 );
+has blocks => ( is => 'rw', required => 1,  trigger => 1);
 has blocks_loader => ( is => 'ro', required => 1 );
 has page_root => ( is => 'ro', required => 1 );
 has page_spice => ( is => 'ro', required => 1 );
@@ -47,7 +47,7 @@ has ua => (
 	},
 );
 
-sub BUILD {
+sub _trigger_blocks {
 	my ( $self ) = @_;
 	my %share_dir_hash;
 	my %path_hash;
@@ -209,9 +209,10 @@ sub request {
 		my @calls_script = ();
 		my %calls_template = ();
 
-		my $blocks = $self->blocks_loader->() // $self->blocks;
-
-		for (@$blocks) {
+		if (my $updated_blocks = $self->blocks_loader->()) {
+			 $self->blocks($updated_blocks);
+		}
+		for (@{$self->blocks}) {
 			push(@results,$_->request($ddg_request));
 		}
 

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -19,7 +19,7 @@ use URI::Escape;
 use JSON;
 use Data::Dumper;
 
-has blocks => ( is => 'ro', required => 1 );
+has blocks_loader => ( is => 'ro', required => 1 );
 has page_root => ( is => 'ro', required => 1 );
 has page_spice => ( is => 'ro', required => 1 );
 has page_css => ( is => 'ro', required => 1 );
@@ -51,7 +51,7 @@ sub BUILD {
 	my %share_dir_hash;
 	my %path_hash;
 	my %rewrite_hash;
-	for (@{$self->blocks}) {
+	for (@{$self->blocks_loader->()}) {
 		for (@{$_->only_plugin_objs}) {
 			if ($_->does('DDG::IsSpice')) {
 				$rewrite_hash{ref $_} = $_->rewrite if $_->has_rewrite;
@@ -208,7 +208,7 @@ sub request {
 		my @calls_script = ();
 		my %calls_template = ();
 
-		for (@{$self->blocks}) {
+		for (@{$self->blocks_loader->()}) {
 			push(@results,$_->request($ddg_request));
 		}
 

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -19,6 +19,7 @@ use URI::Escape;
 use JSON;
 use Data::Dumper;
 
+has blocks => ( is => 'ro', required => 1 );
 has blocks_loader => ( is => 'ro', required => 1 );
 has page_root => ( is => 'ro', required => 1 );
 has page_spice => ( is => 'ro', required => 1 );
@@ -51,7 +52,7 @@ sub BUILD {
 	my %share_dir_hash;
 	my %path_hash;
 	my %rewrite_hash;
-	for (@{$self->blocks_loader->()}) {
+	for (@{$self->blocks}) {
 		for (@{$_->only_plugin_objs}) {
 			if ($_->does('DDG::IsSpice')) {
 				$rewrite_hash{ref $_} = $_->rewrite if $_->has_rewrite;
@@ -208,7 +209,9 @@ sub request {
 		my @calls_script = ();
 		my %calls_template = ();
 
-		for (@{$self->blocks_loader->()}) {
+		my $blocks = $self->blocks_loader->() // $self->blocks;
+
+		for (@$blocks) {
 			push(@results,$_->request($ddg_request));
 		}
 


### PR DESCRIPTION
This makes code reloading available. This was not as easy as one might hope, given the inside-out way we do things with our object construction.  For these reasons, this code depends on [a change to DDG](https://github.com/duckduckgo/duckduckgo/pull/106) and isn't as efficient as it might otherwise be.  Hopefully still more efficient than stopping and restarting the server constantly.

- `ia_type` and `all_module` list are changed into attributes.
- The all_module list is cleared if we note a modification since last check.
- Otherwise, the module list is scanned and and reloaded as necessary via the `again` module.
- If any changes are noted, we regenerate the blocks.

Essentially all of the above is done in a closure which is passed to each blocks users (Server and Query) so that they can get the updated blocks at the appropriate times.

This has been manually tested to cover adding, removing and modifying packages while the process is running.