### PR TITLE
Normalize usage of MooX::Options in Cmds

### DIFF
--- a/lib/App/DuckPAN/Cmd/Help.pm
+++ b/lib/App/DuckPAN/Cmd/Help.pm
@@ -3,6 +3,8 @@ package App::DuckPAN::Cmd::Help;
 
 use Moo;
 with qw( App::DuckPAN::Cmd );
+
+use MooX::Options protect_argv => 0;
 use Pod::Usage qw(pod2usage);
 
 sub run {

--- a/lib/App/DuckPAN/Cmd/New.pm
+++ b/lib/App/DuckPAN/Cmd/New.pm
@@ -12,6 +12,8 @@ package App::DuckPAN::Cmd::New;
 
 use Moo;
 with qw( App::DuckPAN::Cmd );
+
+use MooX::Options protect_argv => 0;
 use Text::Xslate qw(mark_raw);
 use Path::Tiny;
 

--- a/lib/App/DuckPAN/Cmd/Publisher.pm
+++ b/lib/App/DuckPAN/Cmd/Publisher.pm
@@ -5,7 +5,6 @@ use Moo;
 with qw( App::DuckPAN::Cmd );
 
 use MooX::Options protect_argv => 0;
-
 use Path::Tiny;
 use Plack::Handler::Starman;
 

--- a/lib/App/DuckPAN/Cmd/Query.pm
+++ b/lib/App/DuckPAN/Cmd/Query.pm
@@ -2,8 +2,9 @@ package App::DuckPAN::Cmd::Query;
 # ABSTRACT: Command line tool for testing queries and see triggered instant answers
 
 use MooX;
-use MooX::Options protect_argv => 0;
 with qw( App::DuckPAN::Cmd );
+
+use MooX::Options protect_argv => 0;
 
 sub run {
 	my ($self, @args) = @_;

--- a/lib/App/DuckPAN/Cmd/Release.pm
+++ b/lib/App/DuckPAN/Cmd/Release.pm
@@ -2,8 +2,9 @@ package App::DuckPAN::Cmd::Release;
 # ABSTRACT: Release the distribution of the current directory
 
 use MooX;
-use MooX::Options protect_argv => 0;
 with qw( App::DuckPAN::Cmd );
+
+use MooX::Options protect_argv => 0;
 
 sub run {
     my ( $self ) = @_;

--- a/lib/App/DuckPAN/Cmd/Roadrunner.pm
+++ b/lib/App/DuckPAN/Cmd/Roadrunner.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Roadrunner;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 use Time::HiRes qw( usleep );
 
 sub run {

--- a/lib/App/DuckPAN/Cmd/Setup.pm
+++ b/lib/App/DuckPAN/Cmd/Setup.pm
@@ -4,7 +4,7 @@ package App::DuckPAN::Cmd::Setup;
 use Moo;
 with qw( App::DuckPAN::Cmd );
 
-use MooX::Options;
+use MooX::Options protect_argv => 0;
 use Email::Valid;
 
 option user => (

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -2,8 +2,9 @@ package App::DuckPAN::Cmd::Test;
 # ABSTRACT: Command for running the tests of this library
 
 use MooX;
-use MooX::Options protect_argv => 0;
 with qw( App::DuckPAN::Cmd );
+
+use MooX::Options protect_argv => 0;
 
 sub run {
     my ( $self ) = @_;


### PR DESCRIPTION
//cc @killerfish @mwmiller 

We should be using `use MooX::Options protect_argv => 0;` in all our commands so they will respect command line args (like `--help, --force`). This updates any Cmds that weren't using it.
