### PR TITLE
Spice.failed() frontend notice

### DIFF
--- a/share/duckpan.js
+++ b/share/duckpan.js
@@ -3,6 +3,9 @@
 	// grab original Spice.failed to be called later
 	var oldSpiceFailed = Spice.failed;
 
+	// Create div to collect our warnings
+	$('div.content-wrap').append('<div id="spice-errors"></div>');
+
 	// define new Spice.failed which calls the original
 	// and then notifies devs on the frontend
 	env.Spice.failed = function (ia) {
@@ -15,12 +18,7 @@
 		}
 
 		var errorMsg = 'Spice.failed() called by Spice with ID "' + ia + '".',
-			$errorDiv = $('<div class="msg msg--warning">' + errorMsg + '</div>');
-
-		// Create div to collect our warnings
-		if ( !$('#spice-errors').length ){
-			$('div.content-wrap').append('<div id="spice-errors"></div>');
-		}
+			$errorDiv = $('<div>').attr("class", "msg msg--warning").text(errorMsg);
 
 		// Alert on frontend
 		$('#spice-errors').append($errorDiv);


### PR DESCRIPTION
This should make it much clearer when your Spice (or any others) have called `Spice.failed()` by adding a div to the page indicating what's happened - rather than seeing a blank page.

Ex.
![hacker_news_asdfghjkl123456789_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/5208293/dd2c77ca-7580-11e4-97e1-b2292e97c408.png)

![hacker_news_asdfghjkl123456789_rubygems_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/5208304/07fdfbf4-7581-11e4-9b64-9db43d7fa7d8.png)

//cc @russellholt @jagtalon @killerfish 
