### PR TITLE
Pass @args along to cpanm, allows --force, --verbose, etc

### DIFF
--- a/lib/App/DuckPAN/Cmd/Install.pm
+++ b/lib/App/DuckPAN/Cmd/Install.pm
@@ -13,7 +13,7 @@ sub run {
 		$self->app->emit_info("Found a dist.ini, suggesting a Dist::Zilla distribution");
 
 		$self->app->perl->cpanminus_install_error
-			if (system("dzil install --install-command 'cpanm .'"));
+			if (system("dzil install --install-command 'cpanm .' @args"));
 		$self->app->emit_info("Everything fine!");
 	}
 


### PR DESCRIPTION
Small fix, I noticed I couldn't pass along any args to cpanm when trying to force an install of DuckPAN that had a failing test. This makes things a little easier.

//cc @jagtalon @killerfish @russellholt 
