### PR TITLE
Automatic duckpan app restart on IA update

### DIFF
--- a/lib/App/DuckPAN/Cmd/Query.pm
+++ b/lib/App/DuckPAN/Cmd/Query.pm
@@ -2,18 +2,26 @@ package App::DuckPAN::Cmd::Query;
 # ABSTRACT: Command line tool for testing queries and see triggered instant answers
 
 use MooX;
-with qw( App::DuckPAN::Cmd );
+with qw( App::DuckPAN::Cmd App::DuckPAN::Restart );
 
 use MooX::Options protect_argv => 0;
 
+# Entry point into app
+
 sub run {
-	my ($self, @args) = @_;
+    my ($self, @args) = @_;
 
-	$self->app->check_requirements;    # Will exit if missing
-	my @blocks = @{$self->app->ddg->get_blocks_from_current_dir(@args)};
+    exit $self->run_restarter(\@args);
+}
 
-	require App::DuckPAN::Query;
-	exit App::DuckPAN::Query->run($self->app, @blocks);
+sub _run_app {
+    my ($self, $args) = @_;
+
+    $self->app->check_requirements;    # Will exit if missing
+    my @blocks = @{$self->app->ddg->get_blocks_from_current_dir(@$args)};
+
+    require App::DuckPAN::Query;
+    App::DuckPAN::Query->run($self->app, \@blocks);
 }
 
 1;

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -15,8 +15,6 @@ use Config::INI;
 use Data::Printer;
 use Data::Dumper;
 use Term::ProgressBar;
-use File::Find::Rule;
-use Filesys::Notify::Simple;
 
 option port => (
     is => 'ro',
@@ -148,7 +146,7 @@ sub _run_app {
     );
     #$runner->loader->watch("./lib");
     $runner->parse_options("--port", $self->port);
-    $runner->run;
+    exit $runner->run;
 }
 
 sub slurp_or_empty {

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -13,7 +13,6 @@ use LWP::Simple;
 use HTML::TreeBuilder;
 use Config::INI;
 use Data::Printer;
-use Data::Dumper;
 use Term::ProgressBar;
 
 option port => (

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -2,95 +2,128 @@ package App::DuckPAN::Query;
 # ABSTRACT: Main application/loop for duckpan query
 
 use Moo;
-
-my $query;
-my $history_path;
-
+use DDG;
+use DDG::Request;
+use DDG::Test::Location;
+use DDG::Test::Language;
 use Data::Printer;
+use Data::Dumper;
 use POE qw( Wheel::ReadLine );
+use Try::Tiny;
 
+#my $powh_readline;
+
+# Entry into the module.
 sub run {
-	my ( $self, $app, @blocks ) = @_;
+    my ( $self, $app, $blocks ) = @_;
 
-	require DDG;
-	DDG->import;
-	require DDG::Request;
-	DDG::Request->import;
-	require DDG::Test::Location;
-	DDG::Test::Location->import;
-	require DDG::Test::Language;
-	DDG::Test::Language->import;
+    # Main session. All events declared have equivalent subs.
+    POE::Session->create(
+        package_states => [
+            $self => [qw(_start _stop _get_user_input _got_user_input _run_query)]
+        ],
+        args => [$app, $blocks] # passed to _start
+    );
+    POE::Kernel->run();
 
-	$history_path = $app->cfg->cache_path->child("query_history");
-
-	$app->emit_info('(Empty query for ending test)');
-	while (1) {
-
-		POE::Session->create(
-	      inline_states=> {
-	        _start => \&setup_console,
-	        got_user_input => \&handle_user_input,
-	      }
-	    );
-
-	    POE::Kernel->run();
-
-	    last unless $query;
-
-		eval {
-			my $request = DDG::Request->new(
-				query_raw => $query,
-				location => test_location_by_env(),
-				language => test_language_by_env(),
-			);
-			my $hit;
-			for my $b (@blocks) {
-				for ($b->request($request)) {
-					$hit = 1;
-					$app->emit_info('---', p($_, colored => $app->colors), '---');
-				}
-			}
-			unless ($hit) {
-				$app->emit_info("Sorry, no hit on your instant answer")
-			}
-		};
-		if ($@) {
-			my $error = $@;
-			if ($error =~ m/Malformed UTF-8 character/) {
-				$app->emit_info(
-					"You got a malformed utf8 error message, which normally means that you try to entered a special character on the query prompt, but your interface is not properly configured for utf8. Please check out the documentation of your terminal, ssh client or whatever client you use to access the shell of this system"
-				);
-			}
-			$app->emit_info("Caught error:", $error);
-		}
-	}
-	$app->emit_info("\\_o< Thanks for testing!");
-	return 0;
+    return 0;
 }
 
-sub handle_user_input {
-  my ($input, $exception) = @_[ARG0, ARG1];
-  my $console = $_[HEAP]{console};
+# Initialize the main session. Called once by default.
+sub _start {
+    my ($k, $h, $app, $blocks) = @_[KERNEL, HEAP, ARG0, ARG1];
 
-  exit 0 unless defined $input;
+    my $history_path = $app->cfg->cache_path->child('query_history');
 
-  unless ($input eq ""){
-    $console->put("  You entered: $input");
-    $console->addhistory($input);
-    $console->write_history($history_path);
-  }
-  $query = $input;
+    # Session that handles user input
+    my $powh_readline = POE::Wheel::ReadLine->new(
+        InputEvent => '_got_user_input'
+    );
+    $powh_readline->bind_key("C-\\", "interrupt");
+    $powh_readline->read_history($history_path);
+    $powh_readline->put('(Empty query for ending test)');
+
+    # Store in the heap for use in other events
+    @$h{qw(app blocks console history_path)} = ($app, $blocks, $powh_readline, $history_path);
+
+    $k->sig(TERM => '_stop');
+    # Queue user input event
+    $k->yield('_get_user_input');
+}
+
+sub _default { warn "Unhandled event - $_[ARG0]" }
+
+# The session is about to stop.  Ensure that the ReadLine object is
+# deleted, so it can place your terminal back into a sane mode.  This
+# function is triggered by POE's "_stop" event.
+sub _stop {
+    undef $_[HEAP]->{console}; #powh_readline;
+    exit;
+}
+
+# Event to handle user input, triggered by ReadLine
+sub _got_user_input {
+    my ($k, $h, $input) = @_[KERNEL, HEAP, ARG0];
+
+    # If we have input, send it off to be processed
+    if($input){
+        my ($console, $history_path) = @$h{qw(console history_path)};
+
+        $console->put("  You entered: $input");
+        $console->addhistory($input);
+        $console->write_history($history_path);
+        $k->yield(_run_query => $input); # this yield keeps the loop going
+    }
+    else{
+        $h->{console}->put('\\_o< Thanks for testing!');
+    }
+    # falling through here without queuing an event ends the app.
+}
+
+# Event that prints the prompt and waits for input.
+sub _get_user_input {
+    $_[HEAP]{console}->get('Query: ');
+}
+
+# Event that processes the query
+sub _run_query {
+    my ($k, $h, $query) = @_[KERNEL, HEAP, ARG0];    
+    
+    my ($app, $blocks) = @$h{qw{app blocks}};
+
+    try {
+        my $request = DDG::Request->new(
+            query_raw => $query,
+            location => test_location_by_env(),
+            language => test_language_by_env(),
+        );
+        my $hit;
+        # Iterate through the IAs passing each the query request
+        for my $b (@$blocks) {
+            for ($b->request($request)) {
+                $hit = 1;
+                $app->emit_info('---', p($_, colored => $app->colors), '---');
+            }
+        }
+        unless ($hit) {
+            $app->emit_info('Sorry, no hit on your instant answer')
+        }
+    }
+    catch {
+        my $error = $_;
+        if ($error =~ m/Malformed UTF-8 character/) {
+            $app->emit_info('You got a malformed utf8 error message. Normally' . 
+                ' it means that you tried to enter a special character at the query' . 
+                ' prompt but your interface is not properly configured for utf8.' . 
+                ' Please check the documentation for your terminal, ssh client' .
+                ' or other client used to execute duckpan.'
+            );
+        }
+        $app->emit_info("Caught error: $error");
+    };
+
+    # Enqueue input event
+    $k->yield('_get_user_input');
 }
  
-sub setup_console {
-  my $powh_readline = POE::Wheel::ReadLine->new(
-    InputEvent => 'got_user_input'
-  );
-  $powh_readline->bind_key("C-\\", "interrupt");
-  $_[HEAP]{console} = $powh_readline;
-  $_[HEAP]{console}->read_history($history_path);
-  $_[HEAP]{console}->get("Query: ");
-}
-
-
 1;

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -7,11 +7,8 @@ use DDG::Request;
 use DDG::Test::Location;
 use DDG::Test::Language;
 use Data::Printer;
-use Data::Dumper;
 use POE qw( Wheel::ReadLine );
 use Try::Tiny;
-
-#my $powh_readline;
 
 # Entry into the module.
 sub run {

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -2,7 +2,6 @@ package App::DuckPAN::Query;
 # ABSTRACT: Main application/loop for duckpan query
 
 use Moo;
-use DDG;
 use DDG::Request;
 use DDG::Test::Location;
 use DDG::Test::Language;

--- a/lib/App/DuckPAN/Restart.pm
+++ b/lib/App/DuckPAN/Restart.pm
@@ -1,0 +1,98 @@
+package App::DuckPAN::Restart;
+# ABSTRACT: Automatic restarting of application on file change
+
+use File::Find::Rule;
+use Filesys::Notify::Simple;
+
+use strict;
+
+use Moo::Role;
+
+requires '_run_app';
+
+sub run_restarter {
+    my ($self, $args) = @_;
+
+    # will keep (re)starting the server until user ctrl-c
+    while(1){
+        defined(my $app = fork) or die 'Failed to fork application';
+        unless($app){ # app kid
+            $self->_run_app($args);
+            exit 0;
+        }
+
+        my $fmon = fork;
+        unless($fmon){ # file monitor kid
+            unless(defined $fmon){
+                kill SIGTERM => $app;
+                die 'Failed to fork file monitor';
+            }
+            $self->_monitor_directories;
+            exit 0;
+        }
+
+        # wait for one them to exit
+        my $pid = waitpid -1, 0;
+
+        # reload the application
+        if($pid == $fmon){
+            # if we can't kill the app, let's not start another
+            unless(kill SIGTERM => $app){
+                die "Failed to kill the application (pid: $app). Check manually";
+            }
+            # wait for it, otherwise the next whie loop will get it
+            waitpid($app, 0);
+        }
+        elsif($pid == $app){ # or exit
+            kill SIGTERM => $fmon;
+            exit;
+        }
+        else{ die "Unknown kid $pid reaped!\n"; } # shouldn't happen
+    }
+}
+
+# Monitors development directories for file changes.  Tries to get the
+# list of directories in a general way.  This subroutine 
+# blocks, so when it returns we know there's been a change
+sub _monitor_directories {
+    my $self  = shift;
+
+    # Find all of the directories that neeed to monitored
+    my %distinct_dirs;
+    while(my ($type, $io) = each %{$self->app->get_ia_type()->{templates}}){
+        next if $type eq 'test'; # skip the test dir?
+        # Get any subdirectories
+        my @d = File::Find::Rule->directory()->in($io->{out});
+        ++$distinct_dirs{$_} for @d;
+    }
+    ++$distinct_dirs{$self->app->get_ia_type()->{dir}};
+    # No dupes
+    my @dirs = keys %distinct_dirs;
+    FSMON: while(1){
+        # Find all subdirectories
+        # Create our watcher with each directory
+        my $watcher = Filesys::Notify::Simple->new(\@dirs);
+        # Wait for something to happen.  This blocks, which is why
+        # it's in a wheel.  On detection of update it will fall
+        # through; thus the while(1)
+        my $reload;
+        $watcher->wait(sub {
+            for my $event (@_) {
+                my $file = $event->{path};
+                # if it's just a newly created directory or a dot file,
+                # there shouldn't be a need to reload.  This will catch
+                # directories with files in them properly, as each file
+                # will be its own event
+                if( (-d $file) || ($file =~ m{^(?:.+/)?\.[^/]+$}o)){
+                    next;
+                }
+                # All other changes trigger a reload
+                ++$reload;
+            }
+        });
+        # time to reload or keep waiting
+        last FSMON if $reload;
+    }
+}
+
+1;

--- a/lib/App/DuckPAN/Restart.pm
+++ b/lib/App/DuckPAN/Restart.pm
@@ -13,7 +13,10 @@ requires '_run_app';
 sub run_restarter {
     my ($self, $args) = @_;
 
-    # will keep (re)starting the server until user ctrl-c
+    # exit immediately if not in an IA directory
+    $self->app->get_ia_type;
+
+    # will keep (re)starting the server until the app exits
     while(1){
         defined(my $app = fork) or die 'Failed to fork application';
         unless($app){ # app kid


### PR DESCRIPTION
**Which issues (if any) does this change solve? (please link them here)**
https://github.com/duckduckgo/p5-app-duckpan/issues/52

**Briefly describe your fix. Are there any important details we should know about?**
Alternate strategy to https://github.com/duckduckgo/p5-app-duckpan/pull/175 code reloading.  Adds the role App::DuckPAN::Restart which _restarts_ the running duckpan application automatically when instant answer code is changed.

Incorporates https://github.com/duckduckgo/p5-app-duckpan/pull/190 as well since the current query console does not exit cleanly when killed.





