### PR TITLE
VMs: Revert MD5 and filenames to 2014-12-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,18 @@ The purpose of our DuckDuckHack VM is to provide a sandbox for DuckDuckGo Instan
 
 #### For VirtualBox hosts
 
-ddh-vbox-2014-12-23.ova:
+ddh-vbox-2014-12-13.ova:
 
-MD5: 02a0fb03db2b2466504bf9fbc894c7dd
-
+MD5: 3333a88845cced2fe02aea405c09596a
 
 https://ddg-community.s3.amazonaws.com/ddh-vbox-2014-12-13.ova
 
+
 #### For VMWare hosts
 
-ddh-vmw-2014-12-23.ova:
+ddh-vmw-2014-12-13.ova:
 
-MD5: 6ecdeb8ead2c2eb7a9aba1db22359c4b
+MD5: 02616f507b9ad613e12290baf9a5b41f
 
 https://ddg-community.s3.amazonaws.com/ddh-vmw-2014-12-13.ova
 


### PR DESCRIPTION
@moollaza  There was a miscommunication in #182. The 2014-12-23 VMs have not been uploaded yet. The 2014-12-13 VMs are older, but they have been uploaded and their URL is specified in your last commit. So let's specify their details.
