### PR TITLE
Make sure DDG installed when testing DuckPAN

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -105,3 +105,4 @@ debug = 0
 perl_version = 5.14
 perl_version = 5.16
 perl_version = 5.18
+after_install = duckpan DDG


### PR DESCRIPTION
It seems that Travis tests are failing because DDG::Request cannot be found in @INC. I believe this is because Travis doesn't have DDG installed, so this should solve our problems.