### PR TITLE
Remove conditionally defining $VERSION, allow PkgVersion to set it

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -25,8 +25,6 @@ use Perl::Version;
 use Path::Tiny;
 use App::DuckPAN::Cmd::Help;
 
-our $VERSION ||= '9.999';
-
 option dukgo_login => (
 	is => 'ro',
 	lazy => 1,


### PR DESCRIPTION
This caused problems during the most recent release of DuckPAN. `PkgVersion` did not set a `$VERSION` for `App::DuckPAN` because it detected `$VERSION` was being defined in the code (`our $VERSION ||= '9.999'`). This resulted in `App::DuckPAN` not having any `$VERSION` in the final build, which meant the DuckPAN package currently has no version on duckpan.org

This is causing problems for `App::DuckPAN` because it thinks the local version is now higher than what duckpan.org has (version 0), which means DuckPAN will not upgrade!

This fix removes any explicit definition of `$VERSION` so `PkgVersion` can set it properly.

The only unknown is why this problem started occurring now, because the code has been in this state for over 2 years...I suspect a change in PkgVersion but I'm not sure yet.

//cc @jbarrett @jagtalon @russellholt 