### PR TITLE
Revert "Update Travis.yml to allow for faster Travis builds"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - rm .travis.yml


### PR DESCRIPTION
Reverts duckduckgo/p5-app-duckpan#206

For some reason this is causing problems for me when trying to release DuckPAN. The build process is removing the `sudo: false` line and creates uncommitted changes, which makes it impossible for me to release DuckPAN.

No idea why this is happening now...Likely the fact that we have .travis.yml in the repo, and we're creating one via the Travis Dzil Plugin in the dist.ini