### PR TITLE
DuckPAN Dev Versioning

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -100,7 +100,7 @@ option duckpan => (
 sub _ua_string {
   my ($self) = @_;
   my $class   = ref $self || $self;
-  my $version = $class->VERSION;
+  my $version = $class->VERSION; || 'dev';
   return "$class/$version";
 }
 

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -100,7 +100,7 @@ option duckpan => (
 sub _ua_string {
   my ($self) = @_;
   my $class   = ref $self || $self;
-  my $version = $class->VERSION; || 'dev';
+  my $version = $class->VERSION || '9.999';
   return "$class/$version";
 }
 

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -119,10 +119,11 @@ sub duckpan_install {
 				}
 			}
 		} elsif ($localver == $duckpan_module_version) {
-			$message = "You already have latest ($localver) version of $package";
+			$message = "You already have latest version ($localver) of $package";
 		} elsif ($localver > $duckpan_module_version) {
-			$message = "You have a newer ($localver) version of $package than duckpan ($duckpan_module_version)";
+			$message = "You have a newer version ($localver) of $package than duckpan.org ($duckpan_module_version)";
 		} else {
+			$message = "You have an outdated version ($localver) of $package than duckpan.org. Installing latest version ($duckpan_module_version)";
 			$install_it = 1;
 		}
 		$self->app->emit_info($message);

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -55,8 +55,15 @@ sub get_local_version {
 		} or return;
 	};
 
-	return 'dev' unless (defined $v && $module eq 'App::DuckPAN');
-	return unless defined $v;
+	unless (defined $v) {
+        if ($module eq 'App::DuckPAN' || $module eq 'DDG'){
+            # When executing code in-place, $VERSION will not be defined.
+            # Only the installed package will have a defined version
+            # thanks to Dist::Zilla::Plugin::PkgVersion
+            return '9.999';
+        }
+        return;
+    }
 	return version->parse($v) unless ref $v;
 	return $v;
 }
@@ -123,7 +130,7 @@ sub duckpan_install {
 		} elsif ($localver > $duckpan_module_version) {
 			$message = "You have a newer version ($localver) of $package than duckpan.org ($duckpan_module_version)";
 		} else {
-			$message = "You have an outdated version ($localver) of $package than duckpan.org. Installing latest version ($duckpan_module_version)";
+			$message = "You have an older version ($localver) of $package than duckpan.org. Installing latest version ($duckpan_module_version)";
 			$install_it = 1;
 		}
 		$self->app->emit_info($message);

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -55,6 +55,7 @@ sub get_local_version {
 		} or return;
 	};
 
+	return 'dev' unless (defined $v && $module eq 'App::DuckPAN');
 	return unless defined $v;
 	return version->parse($v) unless ref $v;
 	return $v;

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -47,6 +47,8 @@ sub get_local_version {
 	my $v;
 	{
 		local $@;
+
+        # ensure $module is installed by trying to load (require) it
 		eval {
 			my $m = Module::Data->new($module);
 			$m->require;
@@ -55,6 +57,11 @@ sub get_local_version {
 		} or return;
 	};
 
+    # $module (e.g. DuckPAN, DDG) has loaded, but no $VERSION exists
+    # This means we're not working with code that was built by DZIL
+    #
+    # Example:
+    # > ./bin/duckpan -I/lib/ -I../duckduckgo/lib server
 	unless (defined $v) {
         if ($module eq 'App::DuckPAN' || $module eq 'DDG'){
             # When executing code in-place, $VERSION will not be defined.

--- a/t/app_duckpan.t
+++ b/t/app_duckpan.t
@@ -10,7 +10,7 @@ delete $ENV{APP_DUCKPAN_SERVER_HOSTNAME};
 
 use App::DuckPAN;
 
-my $version = $App::DuckPAN::VERSION;
+my $version = $App::DuckPAN::VERSION || 'dev';
 
 my $tempdir = Path::Tiny->tempdir(CLEANUP => 1);
 

--- a/t/app_duckpan.t
+++ b/t/app_duckpan.t
@@ -10,7 +10,7 @@ delete $ENV{APP_DUCKPAN_SERVER_HOSTNAME};
 
 use App::DuckPAN;
 
-my $version = $App::DuckPAN::VERSION || 'dev';
+my $version = $App::DuckPAN::VERSION || '9.999';
 
 my $tempdir = Path::Tiny->tempdir(CLEANUP => 1);
 
@@ -32,7 +32,7 @@ isa_ok($app->cfg,'App::DuckPAN::Config');
 
 SKIP: {
 	skip "No DDG installed yet", 2 unless try_load_class('DDG');
-	my $ddg_version = $DDG::VERSION;
+	my $ddg_version = $DDG::VERSION || '9.999';
 	isa_ok($app->ddg,'App::DuckPAN::DDG');
 	is($app->get_local_ddg_version,$ddg_version,'Checking get_local_ddg_version');
 }

--- a/t/system_duckpan.t
+++ b/t/system_duckpan.t
@@ -8,8 +8,6 @@ use Path::Tiny;
 
 use App::DuckPAN;
 
-my $version = $App::DuckPAN::VERSION;
-
 subtest 'no arguments' => sub {
 	my ($return, $out, $err) = run_script('duckpan', []);
 


### PR DESCRIPTION
When DuckPAN is built and installed via `Dist::Zilla`, the `PkgVersion` plugin injects a line that sets the package's `$VERSION` based on the current Git Tag for the DuckPAN repo. Previously, DuckPAN would set `$VERSION` to `'9.999'` if it wasn't set by PkgVersion, which only occurred when DuckPAN was run 'in place' from the repo, i.e. `./bin/duckpan -I /lib`.

A bug was recently fixed in `PkgVersion` which forces it to **not** inject a `$VERSION = ` line for any files that explicitly set a value for `$VERSION`. (We've just been getting lucky for the past few years).

This means the `our $VERSION ||= '9.999'` line in `App::DuckPAN` had to be removed and a "dev" version must be set in another manner.

This PR sets the `$VERSION` to `'9.999'` in those cases.

---

**Note:** The DDG (duckduckgo/duckduckgo) Module has the name `our $VERSION ||= '9.999'` line, which will soon be removed. Currently DuckPAN is the only software which expects DDG to ever have a version of `9.999`

/cc @russellholt @jagtalon @zachthompson @MrChrisW @jbarrett 