### PR TITLE
Provide more information when installing module for the first time

### DIFF
--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -118,6 +118,7 @@ sub duckpan_install {
 
 		my ($install_it, $message);
 		if ($reinstall || !$localver) {    # Note the ignored pinning.
+			$message = "You don't have $package installed. Installing latest version ($duckpan_module_version)";
 			$install_it = 1;
 		} elsif ($pin_version) {
 			$self->app->emit_info("$package: $localver installed, $pin_version pin, $duckpan_module_version latest");


### PR DESCRIPTION
I found it a little annoying that when installing something for the first time, DuckPAN doesn't explicitly tell you what version of the module was found on duckpan.org and will be installed.

This does that :)