### PR TITLE
Inject mock ad and results into SERP for realistic look

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -386,7 +386,10 @@ sub request {
 				} keys %{ $calls_template{$spice_name} });
 			}
 		}
-		
+
+
+		inject_mock_content($root);
+
 		$page = $root->as_HTML;
 
 		$page =~ s/####DUCKDUCKHACK-CALL-NRJ####/$calls_nrj/g;
@@ -410,6 +413,82 @@ sub request {
 
 	$response->body($body);
 	return $response;
+}
+
+
+#inject some mock results into the SERP to make it look a little more real
+sub inject_mock_content {
+
+    my $root= shift;
+
+    #inject a mock ad into the page
+    my $ad_container = $root->look_down(id => "ads");
+    $ad_container->attr("style", "display: block");
+
+    my $ad = HTML::TreeBuilder->new_from_content(
+        q(<div id="ra-0" class="result results_links highlight_a  result--ad  highlight_sponsored  sponsored highlight highlight_sponsored_hover" data-nir="1">
+            <div class="result__body links_main links_deep">
+                <a href="https://duck.co/help/company/advertising-and-affiliates" class="result__badge  badge--ad">Ad</a>
+                <h2 class="result__title">
+                <a class="result__a" href="">Lorem ipsum Culpa ex adipisicing.</a>
+                <a class="result__check" href="">
+                    <span class="result__check__tt">Lorem ipsum Consectetur nostrud id quis in ut.</span>
+                </a>
+                </h2>
+                <div class="result__snippet">
+                    <a href="">Lorem ipsum Nisi aute velit sit dolore sit amet fugiat consequat aute reprehenderit in dolore deserunt.</a>
+                </div>
+                <div class="result__extras">
+                    <div class="result__extras__url">
+                        <a class="result__url" href="#">duckduckgo.com</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        )
+    )->guts;
+
+    $ad_container->push_content( $ad );
+
+    #inject some mock ad into the page
+    my $links_container = $root->look_down(id => "links");
+
+    for (1..4){
+        $links_container->push_content(
+            HTML::TreeBuilder->new_from_content(
+                q(<div id="r$_-0" class="result results_links_deep " data-nir="$_"
+                    <div class="result__body links_main links_deep">
+                        <h2 class="result__title">
+                        <a class="result__a" href="#">
+                            Lorem ipsum Duis elit voluptate in ut sed culpa nostrud sint est occaecat in irure veniam exercitation
+                        </a>
+                        <a class="result__check" href="#">
+                            <span class="result__check__tt">Your browser indicates if you've visited this link</span>
+                        </a>
+                        </h2>
+                        <div class="result__snippet">
+                            Lorem ipsum Mollit ut voluptate in id laborum nulla adipisicing ad ea do do nisi nulla qui quis do nisi pariatur voluptate minim dolore enim commodo cillum ullamco pariatur culpa.
+                        </div>
+                        <div class="result__extras">
+                            <div class="result__extras__url">
+                                <span class="result__icon">
+                                <a href="#">
+                                    <img title="Search www.duckduckgo.com" id="i101" height="16" width="16" class="result__icon__img" src="//icons.duckduckgo.com/ip2/www.duckduckgo.com.ico">
+                                </a>
+                                </span>
+                                <a class="result__url" href="#">
+                                    <span class="result__url__domain">Lorem.ipsum.com</span>
+                                    <span class="result__url__full">/Incididunt%20reprehenderit%20ullamco.</span>
+                                </a>
+                            </div>
+                            <a href="#">More results</a>
+                        </div>
+                    </div>
+                </div>
+                )
+            )->guts
+        );
+    }
 }
 
 1;

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -421,38 +421,37 @@ sub inject_mock_content {
 
     my $root= shift;
 
-    #inject a mock ad into the page
+    # ensure results and ad containers exist
     my $ad_container = $root->look_down(id => "ads");
     my $links_container = $root->look_down(id => "links");
-
     return unless $ad_container && $links_container;
 
+    #inject a mock ad into the page
     $ad_container->attr("style", "display: block");
 
-    my $ad = HTML::TreeBuilder->new_from_content(
-        q(<div id="ra-0" class="result results_links highlight_a  result--ad  highlight_sponsored  sponsored highlight highlight_sponsored_hover" data-nir="1">
-            <div class="result__body links_main links_deep">
-                <a href="#" class="result__badge  badge--ad">Ad</a>
-                <h2 class="result__title">
-                <a class="result__a" href="#">Lorem ipsum Culpa ex adipisicing.</a>
-                <a class="result__check" href="#">
-                    <span class="result__check__tt">Lorem ipsum Consectetur nostrud id quis in ut.</span>
-                </a>
-                </h2>
-                <div class="result__snippet">
-                    <a href="#">Lorem ipsum Nisi aute velit sit dolore sit amet fugiat consequat aute reprehenderit in dolore deserunt.</a>
-                </div>
-                <div class="result__extras">
-                    <div class="result__extras__url">
-                        <a class="result__url" href="#">duckduckgo.com</a>
+    $ad_container->push_content(
+        HTML::TreeBuilder->new_from_content(
+            q(<div id="ra-0" class="result results_links highlight_a  result--ad  highlight_sponsored  sponsored highlight highlight_sponsored_hover" data-nir="1">
+                <div class="result__body links_main links_deep">
+                    <a href="#" class="result__badge  badge--ad">Ad</a>
+                    <h2 class="result__title">
+                    <a class="result__a" href="#">Lorem ipsum Culpa ex adipisicing.</a>
+                    <a class="result__check" href="#">
+                        <span class="result__check__tt">Lorem ipsum Consectetur nostrud id quis in ut.</span>
+                    </a>
+                    </h2>
+                    <div class="result__snippet">
+                        <a href="#">Lorem ipsum Nisi aute velit sit dolore sit amet fugiat consequat aute reprehenderit in dolore deserunt.</a>
+                    </div>
+                    <div class="result__extras">
+                        <div class="result__extras__url">
+                            <a class="result__url" href="#">duckduckgo.com</a>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </div>
-        )
-    )->guts;
-
-    $ad_container->push_content( $ad );
+            </div>)
+        )->guts
+    );
 
     #inject some mock ad into the page
     for (1..4){
@@ -486,8 +485,7 @@ sub inject_mock_content {
                             <a href="#">More results</a>
                         </div>
                     </div>
-                </div>
-                )
+                </div>)
             )->guts
         );
     }

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -168,7 +168,7 @@ sub request {
 					} else {
 						p($res->status_line, color => { string => 'red' });
 						my $errormsg = (pop @{[split'::', $spice_class]}). ": ".$res->status_line;
-						$body = '$("div.content-wrap").append("<div class=\"msg msg--warning\">'. $errormsg .'</div>");';
+						$body = '$("#message").removeClass("is-hidden").append("<div class=\"msg msg--warning\">'. $errormsg .'</div>");';
 					}
 				}
 			}

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -423,6 +423,10 @@ sub inject_mock_content {
 
     #inject a mock ad into the page
     my $ad_container = $root->look_down(id => "ads");
+    my $links_container = $root->look_down(id => "links");
+
+    return unless $ad_container && $links_container;
+
     $ad_container->attr("style", "display: block");
 
     my $ad = HTML::TreeBuilder->new_from_content(
@@ -451,8 +455,6 @@ sub inject_mock_content {
     $ad_container->push_content( $ad );
 
     #inject some mock ad into the page
-    my $links_container = $root->look_down(id => "links");
-
     for (1..4){
         $links_container->push_content(
             HTML::TreeBuilder->new_from_content(

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -432,15 +432,15 @@ sub inject_mock_content {
     my $ad = HTML::TreeBuilder->new_from_content(
         q(<div id="ra-0" class="result results_links highlight_a  result--ad  highlight_sponsored  sponsored highlight highlight_sponsored_hover" data-nir="1">
             <div class="result__body links_main links_deep">
-                <a href="https://duck.co/help/company/advertising-and-affiliates" class="result__badge  badge--ad">Ad</a>
+                <a href="#" class="result__badge  badge--ad">Ad</a>
                 <h2 class="result__title">
-                <a class="result__a" href="">Lorem ipsum Culpa ex adipisicing.</a>
-                <a class="result__check" href="">
+                <a class="result__a" href="#">Lorem ipsum Culpa ex adipisicing.</a>
+                <a class="result__check" href="#">
                     <span class="result__check__tt">Lorem ipsum Consectetur nostrud id quis in ut.</span>
                 </a>
                 </h2>
                 <div class="result__snippet">
-                    <a href="">Lorem ipsum Nisi aute velit sit dolore sit amet fugiat consequat aute reprehenderit in dolore deserunt.</a>
+                    <a href="#">Lorem ipsum Nisi aute velit sit dolore sit amet fugiat consequat aute reprehenderit in dolore deserunt.</a>
                 </div>
                 <div class="result__extras">
                     <div class="result__extras__url">
@@ -492,5 +492,7 @@ sub inject_mock_content {
         );
     }
 }
+
+1;
 
 1;

--- a/share/duckpan.js
+++ b/share/duckpan.js
@@ -4,7 +4,7 @@
 	var oldSpiceFailed = Spice.failed;
 
 	// Create div to collect our warnings
-	$('div.content-wrap').append('<div id="spice-errors"></div>');
+	$("#message").removeClass("is-hidden").append('<div id="spice-errors"></div>');
 
 	// define new Spice.failed which calls the original
 	// and then notifies devs on the frontend


### PR DESCRIPTION
/cc @mintsoft @MrChrisW @killerfish 

![2015-02-10_00h13_02](https://cloud.githubusercontent.com/assets/873785/6121915/a307f9a6-b0b9-11e4-8484-c4ff736a44f7.png)

Thoughts?

If the real text is too much we could inject colored bars like we do for the IA pages: https://duck.co/ia/view/airlines