### PR TITLE
Custom templates for Goodies

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -272,7 +272,7 @@ sub request {
 					} elsif ($name =~ /handlebars$/){
 						$name =~ s/\.handlebars//;
 						$calls_template{$ia_name}{$name}{"content"} = $_;
-						$calls_template{$ia_name}{$name}{"is_ct_self"} = $result->call_type eq 'self';
+						$calls_template{$ia_name}{$name}{"is_ct_self"} = $is_goodie ? 1 : $result->call_type eq 'self';
 					}
 				}
 				push (@calls_nrj, $result->call_path) if ($result->can('call_path'));
@@ -365,7 +365,8 @@ sub request {
 		if(@calls_goodie){
 			my $goodie = shift @calls_goodie;
 			$calls_nrj = "DDG.duckbar.future_signal_tab({signal:'high',from:'$goodie->{id}'});",
-			$calls_script = q|<script type="text/JavaScript" class="script-run-on-ready">/*DDH.add(| . encode_json($goodie) . q|);*/</script>|
+			#window.setTimeout(DDH.add.bind(DDH, '.encode_for_json($data->{answer_results}) . '), 100
+			$calls_script = q|<script type="text/JavaScript" class="script-run-on-ready">/*window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100);*/</script>|
 		}
 		else{
 			$calls_nrj = @calls_nrj ? join(';', map { "nrj('".$_."')" } @calls_nrj) . ';' : '';

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -366,6 +366,8 @@ sub request {
 		if(@calls_goodie){
 			my $goodie = shift @calls_goodie;
 			$calls_nrj = "DDG.duckbar.future_signal_tab({signal:'high',from:'$goodie->{id}'});",
+			# Uncomment following line and remove "setTimeout" line when javascript race condition is addressed
+			# $calls_script = q|<script type="text/JavaScript" class="script-run-on-ready">/*DDH.add(| . encode_json($goodie) . q|);*/</script>|;
 			$calls_script .= q|<script type="text/JavaScript" class="script-run-on-ready">/*window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100);*/</script>|;
 		}
 		else{

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -359,20 +359,17 @@ sub request {
 		#   calls_nrc : css calls
 		#   calls_template : handlebars templates
 
-		my ($calls_nrj, $calls_script);
+		my $calls_nrj;
+		my $calls_script = join('', map { q|<script type='text/JavaScript' src='| . $_ . q|'></script>| } @calls_script);
 		# For now we only allow a single goodie. If that changes, we will do the
 		# same join/map as with spices.
 		if(@calls_goodie){
 			my $goodie = shift @calls_goodie;
 			$calls_nrj = "DDG.duckbar.future_signal_tab({signal:'high',from:'$goodie->{id}'});",
-			#window.setTimeout(DDH.add.bind(DDH, '.encode_for_json($data->{answer_results}) . '), 100
-			$calls_script = q|<script type="text/JavaScript" class="script-run-on-ready">/*window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100);*/</script>|
+			$calls_script .= q|<script type="text/JavaScript" class="script-run-on-ready">/*window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100);*/</script>|;
 		}
 		else{
 			$calls_nrj = @calls_nrj ? join(';', map { "nrj('".$_."')" } @calls_nrj) . ';' : '';
-			$calls_script = @calls_script
-				? join('',map { "<script type='text/JavaScript' src='".$_."'></script>" } @calls_script)
-				: '';
 		}
 		my $calls_nrc = @calls_nrc ? join(';', map { "nrc('".$_."')" } @calls_nrc) . ';' : '';
 

--- a/share/duckpan.js
+++ b/share/duckpan.js
@@ -72,7 +72,9 @@ $(document).ready(function() {
 			$.each(toCall, function(i, name){
 				var cbName = 'ddg_spice_' + name;
 				console.log('Executing: ' + cbName);
-				window[cbName]();
+				if (typeof window[cbName] == 'function'){
+					window[cbName]();
+				}
 			});
 		}, 100);
 


### PR DESCRIPTION
Adds support for using custom templates with Goodies.  It has been tested with multiple templates and Handlebars helpers (see [DDG::Goodie::GoodieCustomTemplate](https://github.com/duckduckgo/zeroclickinfo-goodies/compare/zach/gtemplatev3) for a basic example; also intermittently available for viewing [here](http://zach.duckduckgo.com:5000/?q=gtc+great!&ia=software).)

There is an issue with templates not being available unless an artificial delay is added to the DDH.add call.  It's being evaluated internally so we may want to wait for the fix.  However, duckpan.js is already doing a similar thing for spices so it might not matter.