### PR TITLE
Update README.md to clarify which VM to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ MD5: 02a0fb03db2b2466504bf9fbc894c7dd
 
 https://ddg-community.s3.amazonaws.com/ddh-vmw-2014-12-23.ova
 
-Filename ddh-vmw-2014-12-23.ova:
+Filename: ddh-vmw-2014-12-23.ova
 
 MD5: 6ecdeb8ead2c2eb7a9aba1db22359c4b
 

--- a/README.md
+++ b/README.md
@@ -106,20 +106,20 @@ The purpose of our DuckDuckHack VM is to provide a sandbox for DuckDuckGo Instan
 
 #### For VirtualBox hosts
 
-ddh-vbox-2014-12-23.ova:
+https://ddg-community.s3.amazonaws.com/ddh-vbox-2014-12-23.ova
+
+Filename: ddh-vbox-2014-12-23.ova
 
 MD5: 02a0fb03db2b2466504bf9fbc894c7dd
-
-https://ddg-community.s3.amazonaws.com/ddh-vbox-2014-12-23.ova
 
 
 #### For VMWare hosts
 
-ddh-vmw-2014-12-23.ova:
+https://ddg-community.s3.amazonaws.com/ddh-vmw-2014-12-23.ova
+
+Filename ddh-vmw-2014-12-23.ova:
 
 MD5: 6ecdeb8ead2c2eb7a9aba1db22359c4b
-
-https://ddg-community.s3.amazonaws.com/ddh-vmw-2014-12-23.ova
 
 
 #### Roadmap


### PR DESCRIPTION
A user made a mistake in issue #225 by downloading the VirtualBox VM for VMware. I think that by moving the URL closer to the section header, we can minimize the likelihood of that mistake.