### PR TITLE
Proper handling of UTF-8 content in _print_msg

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -23,6 +23,7 @@ use Carp;
 use Encode;
 use Perl::Version;
 use Path::Tiny;
+use open qw/:std :utf8/;
 use App::DuckPAN::Cmd::Help;
 
 option dukgo_login => (

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -12,7 +12,6 @@ use Path::Tiny;
 use LWP::Simple;
 use HTML::TreeBuilder;
 use Config::INI;
-use Data::Printer;
 use Term::ProgressBar;
 
 option port => (

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -14,6 +14,7 @@ use HTML::TreeBuilder;
 use Config::INI;
 use Data::Printer;
 use Term::ProgressBar;
+use open qw/:std :utf8/;
 
 option port => (
     is => 'ro',

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -14,7 +14,6 @@ use HTML::TreeBuilder;
 use Config::INI;
 use Data::Printer;
 use Term::ProgressBar;
-use open qw/:std :utf8/;
 
 option port => (
     is => 'ro',

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -5,6 +5,7 @@ use Moo;
 use Data::Printer;
 use POE qw( Wheel::ReadLine );
 use Try::Tiny;
+use open qw/:std :utf8/;
 
 # Entry into the module.
 sub run {

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -17,7 +17,7 @@ use HTTP::Request;
 use LWP::UserAgent;
 use URI::Escape;
 use JSON;
-use Data::Dumper;
+use open qw/:std :utf8/;
 
 has blocks => ( is => 'ro', required => 1 );
 has page_root => ( is => 'ro', required => 1 );


### PR DESCRIPTION
Fixes #232

Before:

![2015-02-27_20h35_50](https://cloud.githubusercontent.com/assets/873785/6424271/8132bf42-bec3-11e4-98a3-cc18af0e5626.png)

After:

![2015-02-27_20h58_58](https://cloud.githubusercontent.com/assets/873785/6424268/784233d6-bec3-11e4-977a-50a22011b050.png)


/cc @zachthompson 