### PR TITLE
Make Web.pm find the correct share dir for IAs that are substring of oth...

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -87,7 +87,7 @@ sub request {
 	} elsif (@path_parts && $path_parts[0] eq 'share') {
 		my $share_dir;
 		for (keys %{$self->_share_dir_hash}) {
-			if ($request->path =~ m|^/$_|g) {
+			if ($request->path =~ m|^/$_/|g) {
 
 				$share_dir = $_;
 				my $filename = pop @path_parts;


### PR DESCRIPTION
In duckduckgo/zeroclickinfo-spice the Time spice's name is a substring
of the Timer spice's name. When looking for resources for the Timer
IA, paths of the form

  .../timer/...

got mangled to

  .../time/r/...

because the matcher for IAs share directories did not check for the
trailing path separator. Hence, the share path of the Time (no trailing
“r” in Time) matched for Timer (trailing “r” in Timer) resources, and
path handling got confused.

By making the guard for identifying the relevant the share directory
also check on the trailing '/', the share directories of Time and
Timer are properly matched and the Timer IA again properly loads for
'timer 10 seconds'.

Fixes duckduckgo/zeroclickinfo-spice#1625