### PR TITLE
Warn about uppercase triggers (issue #245)

### DIFF
--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -85,19 +85,23 @@ sub get_blocks_from_current_dir {
 			unless ($blocks_plugins{$class->triggers_block_type}) {
 				$blocks_plugins{$class->triggers_block_type} = [];
 			}
-			push @{$blocks_plugins{$class->triggers_block_type}}, $class;
+
+			my $triggers_block_type = $class->triggers_block_type;
+			push @{$blocks_plugins{$triggers_block_type}}, $class;
 
 			# We could potentially do other IA-specific checks here
-			my $trigger_types = $class->get_triggers;
+			# Check for useless uppercase Words triggers so we can warn
+			if($triggers_block_type eq 'Words'){
+				my $trigger_types = $class->get_triggers;
 
-			# Check for useless uppercase triggers so we can warn
-			UC_TRIGGER: for my $triggers (values %$trigger_types){
-				for my $t (@$triggers){
-					if($t =~ /\p{Uppercase}/){
-						push @UC_TRIGGERS, $class;
-						#warn "is $t uppercase?\n";
-						# the first one found should be sufficient.
-						last UC_TRIGGER;
+				UC_TRIGGER: for my $triggers (values %$trigger_types){
+					for my $t (@$triggers){
+						if($t =~ /\p{Uppercase}/){
+							push @UC_TRIGGERS, $class;
+							#warn "is $t uppercase?\n";
+							# the first one found should be sufficient.
+							last UC_TRIGGER;
+						}
 					}
 				}
 			}

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -123,7 +123,7 @@ sub get_blocks_from_current_dir {
     $self->show_failed_modules(\%failed_to_load);
 
 	if(@UC_TRIGGERS){
-		$self->app->emit_notice('Detected potential UPPERCASE triggers in the following instant answers:' . "\n"
+		$self->app->emit_notice('Detected potential UPPERCASE triggers in the following instant answers. If yours is listed, check it out! Only lowercase will work.' . "\n"
 			. p(@UC_TRIGGERS, colored => $self->app->colors));
 	}
 


### PR DESCRIPTION
Add a check for uppercase triggers in instant answers.  Only lowercase will work and this can be a potential source of confusion during development (see issue https://github.com/duckduckgo/p5-app-duckpan/issues/245).

