### PR TITLE
Remove unneeded deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed
-  - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
+  - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl
 perl:
   - '5.14'

--- a/dist.ini
+++ b/dist.ini
@@ -35,59 +35,7 @@ do_metadata = 1
 tag_format = %v
 push_to = origin master
 
-[Prereqs]
-autodie = 2.25
-App::cpanminus = 1.7014
-Class::Load = 0.18
-Config::INI = 0.019
-Crypt::SSLeay = 0.58
-Data::Printer = 0.3
-Dist::Zilla = 4.300007
-Dist::Zilla::Plugin::UploadToDuckPAN = 0.006
-Email::Valid = 0.187
-File::ShareDir::ProjectDistDir = 0.003002
-File::Temp = 0.22
-File::Which = 1.09
-File::Find::Rule = 0.33
-Filesys::Notify::Simple = 0.12
-HTML::TreeBuilder = 5.03
-JSON = 2.9
-List::MoreUtils = 0.33
-LWP::Protocol::https = 6.06
-LWP::Simple = 6.00
-Module::Data = 0.006
-Module::Pluggable = 4.8
-Moo = 1.002000
-MooX = 0.101
-MooX::Cmd = 0.001
-MooX::Options = 3.71
-Parse::CPAN::Packages::Fast = 0.08
-Perl::Version = 1.013
-Pod::Usage = 1.63
-Path::Tiny = 0.058
-Plack = 1.0029
-POE = 1.354
-Term::ANSIColor = 4.03
-Term::UI = 0.30
-Term::ProgressBar = 2.16
-Term::ReadKey = 2.32
-URI = 1.60
-version = 0.96
-Starman = 0.4008
-Text::Xslate = 3.0.0
-Try::Tiny = 0.22
-HTML::Parser = 3.71
-WWW::DuckDuckGo = 0.015
-
-[Prereqs / TestRequires]
-Test::More = 0.98
-Test::LoadAllModules = 0.021
-File::Temp = 0.22
-Test::Script::Run = 0.05
-File::chdir = 0.1008
-Dir::Self = 0.10
-File::FindLib = 0.001001
-File::HomeDir = 1.00
+[AutoPrereqs]
 
 [MetaNoIndex]
 directory = t/

--- a/dist.ini
+++ b/dist.ini
@@ -40,7 +40,6 @@ autodie = 2.25
 App::cpanminus = 1.7014
 Class::Load = 0.18
 Config::INI = 0.019
-CPAN::Repository = 0.007
 Crypt::SSLeay = 0.58
 Data::Printer = 0.3
 Dist::Zilla = 4.300007


### PR DESCRIPTION
The CPAN::Repository dependency is causing failures since Dist::Data is no longer available.  Running tests, I don't see that it's actually needed.

Switch to AutoPrereqs which pulled the right deps as far as I could tell.

Note: the travis build error is from it trying to install the old duckpan which **this** PR should fix!