### PR TITLE
DuckPAN Test: default to prove, add --build for dzil test

### DIFF
--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -6,16 +6,24 @@ with qw( App::DuckPAN::Cmd );
 
 use MooX::Options protect_argv => 0;
 
+option full => (
+	is          => 'ro',
+	lazy        => 1,
+	short       => 'f',
+	default     => sub { 0 },
+	doc         => 'run full test suite via dzil',
+);
+
 sub run {
     my ( $self ) = @_;
 
     my $ret = 0;
 
-    if (-e 'dist.ini') {
-      $ret = system('dzil test');
-      $self->app->emit_error('Could not begin testing. Is Dist::Zilla installed?') if $ret == -1;
+    if ($self->full) {
+        $self->app->emit_error("Could not find dist.ini.") unless -e 'dist.ini';
+        $ret = system('dzil test');
+        $self->app->emit_error('Could not begin testing. Is Dist::Zilla installed?') if $ret == -1;
     } else {
-      $self->app->emit_notice("Could not find dist.ini.");
       $ret = system('prove -Ilib');
     }
 

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -15,19 +15,20 @@ option full => (
 );
 
 sub run {
-    my ( $self ) = @_;
+	my ( $self ) = @_;
 
-    my $ret = 0;
+	my $ret = 0;
 
-    if ($self->full) {
-        $self->app->emit_error("Could not find dist.ini.") unless -e 'dist.ini';
-        $ret = system('dzil test');
-        $self->app->emit_error('Could not begin testing. Is Dist::Zilla installed?') if $ret == -1;
-    } else {
-      $ret = system('prove -Ilib');
-    }
+	if ($self->full) {
+		$self->app->emit_error("Could not find dist.ini.") unless -e "dist.ini";
+		$ret = system("dzil test");
+		$self->app->emit_error("Could not begin testing. Is Dist::Zilla installed?") if $ret;
+	} else {
+		$ret = system("prove -Ilib");
+		$self->app->emit_error("Tests failed! See output above for details") if $ret;
+	}
 
-    return $ret;
+	return $ret;
 }
 
 1;

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -21,11 +21,9 @@ sub run {
 
 	if ($self->full) {
 		$self->app->emit_error("Could not find dist.ini.") unless -e "dist.ini";
-		$ret = system("dzil test");
-		$self->app->emit_error("Could not begin testing. Is Dist::Zilla installed?") if $ret;
+		$self->app->emit_error("Could not begin testing. Is Dist::Zilla installed?") if $ret = system("dzil test");
 	} else {
-		$ret = system("prove -Ilib");
-		$self->app->emit_error("Tests failed! See output above for details") if $ret;
+		$self->app->emit_error("Tests failed! See output above for details") if $ret = system("prove -Ilib");
 	}
 
 	return $ret;


### PR DESCRIPTION
This ensures that any users who run duckpan test won't run into dzil dependency issues (e.g. handlebars, etc)

Partially addresses #254 

/cc @zachthompson 