### PR TITLE
Version check fix

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -469,9 +469,9 @@ sub check_perl {
 
 sub check_app_duckpan {
 	my ($self) = @_;
-	my $ok = 1;
-	my $installed_version = $self->get_local_app_duckpan_version;
+	my $ok                = 1;
 	my $pin_version       = $ENV{"DuckPAN"} || undef;
+	my $installed_version = $self->get_local_app_duckpan_version;
 	return $ok if $installed_version && $installed_version == '9.999';
 	$self->emit_info("Checking for latest App::DuckPAN... ");
 	my $packages = $self->duckpan_packages;
@@ -482,7 +482,7 @@ sub check_app_duckpan {
 	if ($installed_version >= $latest_version) {
 		my $msg = "App::DuckPAN version: $installed_version";
 		$msg .= " (duckpan has " . $module->version . ")" if $installed_version ne $module->version;
-		$self->emit_notice($msg);
+		$self->emit_debug($msg);
 	} else {
 		my @msg = (
 			"You have version $installed_version, latest is " . $module->version . "!",
@@ -496,8 +496,8 @@ sub check_app_duckpan {
 sub check_ddg {
 	my ($self) = @_;
 	my $ok                = 1;
-	my $installed_version = $self->get_local_ddg_version;
 	my $pin_version       = $ENV{"DDG"} || undef;
+	my $installed_version = $self->get_local_ddg_version;
 	return $ok if $installed_version && $installed_version == '9.999';
 	$self->emit_info("Checking for latest DDG Perl package...");
 	my $packages = $self->duckpan_packages;
@@ -510,8 +510,10 @@ sub check_ddg {
 		$msg .= " (duckpan has $latest_version )" if $installed_version ne $latest_version;
 		$self->emit_debug($msg);
 	} elsif ($pin_version && $pin_version < $latest_version){
-			my @msg = ("A newer version of DDG exists: $latest_version.");
-			push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
+			my @msg = (
+				"A newer version of DDG exists: $latest_version.",
+				"You have the version pinned to: $pin_version. Please update your version pin!"
+			);
 			$self->emit_notice(@msg);
 	} else {
 		if ($installed_version) {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -470,18 +470,25 @@ sub check_app_duckpan {
 	my ($self) = @_;
 	my $ok                = 1;
 	my $installed_version = $self->get_local_app_duckpan_version;
+    my $pin_version       = $ENV{"DuckPAN"} || undef;
 	return $ok if $installed_version && $installed_version == '9.999';
 	$self->emit_info("Checking for latest App::DuckPAN... ");
 	my $packages = $self->duckpan_packages;
 	my $module   = $packages->package('App::DuckPAN');
 	my $latest   = $self->duckpan . 'authors/id/' . $module->distribution->pathname;
-	if ($installed_version && version->parse($installed_version) >= version->parse($module->version)) {
+    my $latest_version = version->parse($module->version);
+
+	if ($installed_version >= $latest_version) {
 		my $msg = "App::DuckPAN version: $installed_version";
-		$msg .= " (duckpan has " . $module->version . ")" if $installed_version ne $module->version;
+		$msg .= " (duckpan has $latest_version )" if $installed_version ne $latest_version;
 		$self->emit_debug($msg);
-	} else {
+	} elsif ($pin_version && $pin_version < $latest_version) {
+        my @msg = ("A newer version of DuckPAN exists: $latest_version.");
+        push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
+        $self->emit_notice(@msg);
+    } else {
 		my @msg = ("Please install the latest App::DuckPAN package with: duckpan upgrade");
-		unshift @msg, "You have version " . $installed_version . ", latest is " . $module->version . "!" if ($installed_version);
+		unshift @msg, "You have version: $installed_version, latest is: $latest_version!" if ($installed_version);
 		$self->emit_error(@msg);
 		$ok = 0;
 	}
@@ -492,21 +499,28 @@ sub check_ddg {
 	my ($self) = @_;
 	my $ok                = 1;
 	my $installed_version = $self->get_local_ddg_version;
+    my $pin_version       = $ENV{"DDG"} || undef;
 	return $ok if $installed_version && $installed_version == '9.999';
 	$self->emit_info("Checking for latest DDG Perl package...");
 	my $packages = $self->duckpan_packages;
 	my $module   = $packages->package('DDG');
 	my $latest   = $self->duckpan . 'authors/id/' . $module->distribution->pathname;
-	if ($installed_version && version->parse($installed_version) >= version->parse($module->version)) {
+    my $latest_version = version->parse($module->version);
+
+	if ($installed_version >= $latest_version) {
 		my $msg = "DDG version: $installed_version";
-		$msg .= " (duckpan has " . $module->version . ")" if $installed_version ne $module->version;
+		$msg .= " (duckpan has $latest_version )" if $installed_version ne $latest_version;
 		$self->emit_debug($msg);
-	} else {
+	} elsif ($pin_version && $pin_version < $latest_version){
+            my @msg = ("A newer version of DDG exists: $latest_version.");
+            push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
+            $self->emit_notice(@msg);
+    } else {
 		my @msg = ("Please install the latest DDG package with: duckpan DDG");
 		if ($installed_version) {
-			unshift @msg, "You have version " . $installed_version . ", latest is " . $module->version . "!";
+			unshift @msg, "You have version: $installed_version, latest is: $latest_version!";
 		} else {
-			unshift @msg, "You don't have DDG installed! Latest is " . $module->version . "!";
+			unshift @msg, "You don't have DDG installed! Latest is $latest_version !";
 		}
 		$self->emit_error(@msg);
 		$ok = 0;

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -138,57 +138,57 @@ has ia_types => (
 );
 
 sub _build_ia_types {
-    my $ddg_path = path('lib', 'DDG');
-    my $t_dir = path('t');
-    return [{
-            name      => 'Goodie',
-            dir       => $ddg_path->child('Goodie'),
-            supported => 1,
-            templates => {
-                code => {
-                    in  => path('template', 'lib', 'DDG', 'Goodie', 'Example.pm'),
-                    out => $ddg_path->child('Goodie')
-                },
-                test => {
-                    in  => path('template', 't', 'Example.t'),
-                    out => $t_dir
-                },
-            },
-        },
-        {
-            name      => 'Spice',
-            dir       => $ddg_path->child('Spice'),
-            supported => 1,
-            templates => {
-                code => {
-                    in  => path('template', 'lib', 'DDG', 'Spice', 'Example.pm'),
-                    out => $ddg_path->child('Spice')
-                },
-                test => {
-                    in  => path('template', 't', 'Example.t'),
-                    out => $t_dir
-                },
-                handlebars => {
-                    in  => path('template', 'share', 'spice', 'example', 'example.handlebars'),
-                    out => path('share',    'spice')
-                },
-                js => {
-                    in  => path('template', 'share', 'spice', 'example', 'example.js'),
-                    out => path('share',    'spice')
-                },
-            },
-        },
-        {
-            name      => 'Fathead',
-            dir       => $ddg_path->child('Fathead'),
-            supported => 0
-        },
-        {
-            name      => 'Longtail',
-            dir       => $ddg_path->child('Longtail'),
-            supported => 0
-        },
-    ];
+	my $ddg_path = path('lib', 'DDG');
+	my $t_dir = path('t');
+	return [{
+			name      => 'Goodie',
+			dir       => $ddg_path->child('Goodie'),
+			supported => 1,
+			templates => {
+				code => {
+					in  => path('template', 'lib', 'DDG', 'Goodie', 'Example.pm'),
+					out => $ddg_path->child('Goodie')
+				},
+				test => {
+					in  => path('template', 't', 'Example.t'),
+					out => $t_dir
+				},
+			},
+		},
+		{
+			name      => 'Spice',
+			dir       => $ddg_path->child('Spice'),
+			supported => 1,
+			templates => {
+				code => {
+					in  => path('template', 'lib', 'DDG', 'Spice', 'Example.pm'),
+					out => $ddg_path->child('Spice')
+				},
+				test => {
+					in  => path('template', 't', 'Example.t'),
+					out => $t_dir
+				},
+				handlebars => {
+					in  => path('template', 'share', 'spice', 'example', 'example.handlebars'),
+					out => path('share',    'spice')
+				},
+				js => {
+					in  => path('template', 'share', 'spice', 'example', 'example.js'),
+					out => path('share',    'spice')
+				},
+			},
+		},
+		{
+			name      => 'Fathead',
+			dir       => $ddg_path->child('Fathead'),
+			supported => 0
+		},
+		{
+			name      => 'Longtail',
+			dir       => $ddg_path->child('Longtail'),
+			supported => 0
+		},
+	];
 }
 
 sub get_reply {
@@ -442,8 +442,8 @@ sub check_ssh {
 }
 
 my %perl_versions = (
-    required    => Perl::Version->new('v5.14'),
-    recommended => Perl::Version->new('v5.16'),
+	required    => Perl::Version->new('v5.14'),
+	recommended => Perl::Version->new('v5.16'),
 );
 
 sub check_perl {
@@ -470,23 +470,23 @@ sub check_app_duckpan {
 	my ($self) = @_;
 	my $ok                = 1;
 	my $installed_version = $self->get_local_app_duckpan_version;
-    my $pin_version       = $ENV{"DuckPAN"} || undef;
+	my $pin_version       = $ENV{"DuckPAN"} || undef;
 	return $ok if $installed_version && $installed_version == '9.999';
 	$self->emit_info("Checking for latest App::DuckPAN... ");
 	my $packages = $self->duckpan_packages;
 	my $module   = $packages->package('App::DuckPAN');
 	my $latest   = $self->duckpan . 'authors/id/' . $module->distribution->pathname;
-    my $latest_version = version->parse($module->version);
+	my $latest_version = version->parse($module->version);
 
 	if ($installed_version >= $latest_version) {
 		my $msg = "App::DuckPAN version: $installed_version";
 		$msg .= " (duckpan has $latest_version )" if $installed_version ne $latest_version;
 		$self->emit_debug($msg);
 	} elsif ($pin_version && $pin_version < $latest_version) {
-        my @msg = ("A newer version of DuckPAN exists: $latest_version.");
-        push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
-        $self->emit_notice(@msg);
-    } else {
+		my @msg = ("A newer version of DuckPAN exists: $latest_version.");
+		push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
+		$self->emit_notice(@msg);
+	} else {
 		my @msg = ("Please install the latest App::DuckPAN package with: duckpan upgrade");
 		unshift @msg, "You have version: $installed_version, latest is: $latest_version!" if ($installed_version);
 		$self->emit_error(@msg);
@@ -499,23 +499,23 @@ sub check_ddg {
 	my ($self) = @_;
 	my $ok                = 1;
 	my $installed_version = $self->get_local_ddg_version;
-    my $pin_version       = $ENV{"DDG"} || undef;
+	my $pin_version       = $ENV{"DDG"} || undef;
 	return $ok if $installed_version && $installed_version == '9.999';
 	$self->emit_info("Checking for latest DDG Perl package...");
 	my $packages = $self->duckpan_packages;
 	my $module   = $packages->package('DDG');
 	my $latest   = $self->duckpan . 'authors/id/' . $module->distribution->pathname;
-    my $latest_version = version->parse($module->version);
+	my $latest_version = version->parse($module->version);
 
 	if ($installed_version >= $latest_version) {
 		my $msg = "DDG version: $installed_version";
 		$msg .= " (duckpan has $latest_version )" if $installed_version ne $latest_version;
 		$self->emit_debug($msg);
 	} elsif ($pin_version && $pin_version < $latest_version){
-            my @msg = ("A newer version of DDG exists: $latest_version.");
-            push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
-            $self->emit_notice(@msg);
-    } else {
+			my @msg = ("A newer version of DDG exists: $latest_version.");
+			push @msg, ("You have the version pinned to: $pin_version. Please update your version pin!");
+			$self->emit_notice(@msg);
+	} else {
 		my @msg = ("Please install the latest DDG package with: duckpan DDG");
 		if ($installed_version) {
 			unshift @msg, "You have version: $installed_version, latest is: $latest_version!";
@@ -607,14 +607,14 @@ To contribute to DuckPAN, please visit L<https://github.com/duckduckgo/p5-app-du
 
 B<IRC>:
 
-    We invite you to join us at B<#duckduckgo> on B<irc.freenode.net> for any queries and lively discussion.
+	We invite you to join us at B<#duckduckgo> on B<irc.freenode.net> for any queries and lively discussion.
 
 B<Repository>:
 
-    L<https://github.com/duckduckgo/p5-app-duckpan>
+	L<https://github.com/duckduckgo/p5-app-duckpan>
 
 B<Issue Tracker>:
 
-    L<https://github.com/duckduckgo/p5-app-duckpan/issues>
+	L<https://github.com/duckduckgo/p5-app-duckpan/issues>
 
 =cut

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -123,7 +123,7 @@ sub duckpan_install {
                         "You don't have $package installed. Installing latest version ($duckpan_module_version)";
 			$install_it = 1;
 		} elsif ($pin_version) {
-			$self->app->emit_info("$package: $localver installed, $pin_version pin, $duckpan_module_version latest");
+			$self->app->emit_info("$package: $localver installed, $pin_version pinned, $duckpan_module_version latest");
 			if ($pin_version != $localver) {
 				#  We continue here, even if the version is larger than latest released,
 				#  on the premise that there might exist unreleased development versions.
@@ -131,10 +131,15 @@ sub duckpan_install {
 					$reinstall  = 1;       # Let us roll back, if necessary. Multiple packages may confuse this, but little harm.
 					$install_it = 1;
 				} else {
-					$message    = 'Could not locate version ' . $pin_version . ' of  ' . $package;
-					$install_it = 0;
+                    $message = "Could not locate version $pin_version of \'$package\'";
+                    $self->app->emit_and_exit(-1, $message);
 				}
-			}
+			} else {
+                $message = ($pin_version == $duckpan_module_version) ?
+                    "You already have the latest version of \'$package\' installed!" :
+                    "A newer version of \'$package\' exists. Please update your version pin to match the newest version: $duckpan_module_version";
+                $install_it = 0;
+            }
 		} elsif ($localver == $duckpan_module_version) {
 			$message = "You already have latest version ($localver) of $package";
 		} elsif ($localver > $duckpan_module_version) {

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -131,13 +131,13 @@ sub duckpan_install {
 					$reinstall  = 1;       # Let us roll back, if necessary. Multiple packages may confuse this, but little harm.
 					$install_it = 1;
 				} else {
-					$message = "Could not locate version $pin_version of \'$package\'";
+					$message = "Could not locate version $pin_version of '$package'";
 					$self->app->emit_and_exit(-1, $message);
 				}
 			} else {
 				$message = ($pin_version == $duckpan_module_version) ?
-					"You already have the latest version of \'$package\' installed!" :
-					"A newer version of \'$package\' exists. Please update your version pin to match the newest version: $duckpan_module_version";
+					"You already have the latest version of '$package' installed!" :
+					"A newer version of '$package' exists. Please update your version pin to match the newest version: $duckpan_module_version";
 				$install_it = 0;
 			}
 		} elsif ($localver == $duckpan_module_version) {

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -48,7 +48,7 @@ sub get_local_version {
 	{
 		local $@;
 
-        # ensure $module is installed by trying to load (require) it
+		# ensure $module is installed by trying to load (require) it
 		eval {
 			my $m = Module::Data->new($module);
 			$m->require;
@@ -57,20 +57,20 @@ sub get_local_version {
 		} or return;
 	};
 
-    # $module (e.g. DuckPAN, DDG) has loaded, but no $VERSION exists
-    # This means we're not working with code that was built by DZIL
-    #
-    # Example:
-    # > ./bin/duckpan -I/lib/ -I../duckduckgo/lib server
+	# $module (e.g. DuckPAN, DDG) has loaded, but no $VERSION exists
+	# This means we're not working with code that was built by DZIL
+	#
+	# Example:
+	# > ./bin/duckpan -I/lib/ -I../duckduckgo/lib server
 	unless (defined $v) {
-        if ($module eq 'App::DuckPAN' || $module eq 'DDG'){
-            # When executing code in-place, $VERSION will not be defined.
-            # Only the installed package will have a defined version
-            # thanks to Dist::Zilla::Plugin::PkgVersion
-            return '9.999';
-        }
-        return;
-    }
+		if ($module eq 'App::DuckPAN' || $module eq 'DDG'){
+			# When executing code in-place, $VERSION will not be defined.
+			# Only the installed package will have a defined version
+			# thanks to Dist::Zilla::Plugin::PkgVersion
+			return '9.999';
+		}
+		return;
+	}
 	return version->parse($v) unless ref $v;
 	return $v;
 }
@@ -78,12 +78,12 @@ sub get_local_version {
 sub cpanminus_install_error {
 	shift->app->emit_and_exit(1,
 		"Failure on installation of modules!",
-        "There are several possible explanations and fixes for this error:",
-        "1. The download from CPAN was unsuccessful - Please restart this installer.",
-        "2. Some other error occured - Please read the `build.log` mentioned in the errors and see if you can fix the problem yourself.",
-        "If you are unable to solve the problem, please let us know by making a GitHub Issue in the DuckPAN Repo:",
-        "https://github.com/duckduckgo/p5-app-duckpan/issues",
-        "Make sure to attach the `build.log` file if it exists. Otherwise, copy/paste the output you see."
+		"There are several possible explanations and fixes for this error:",
+		"1. The download from CPAN was unsuccessful - Please restart this installer.",
+		"2. Some other error occured - Please read the `build.log` mentioned in the errors and see if you can fix the problem yourself.",
+		"If you are unable to solve the problem, please let us know by making a GitHub Issue in the DuckPAN Repo:",
+		"https://github.com/duckduckgo/p5-app-duckpan/issues",
+		"Make sure to attach the `build.log` file if it exists. Otherwise, copy/paste the output you see."
 	);
 }
 
@@ -119,8 +119,8 @@ sub duckpan_install {
 		my ($install_it, $message);
 		if ($reinstall || !$localver) {    # Note the ignored pinning.
 			$message = $reinstall ?
-                        "Reinstalling $package. Latest version ($duckpan_module_version)" :
-                        "You don't have $package installed. Installing latest version ($duckpan_module_version)";
+				"Reinstalling $package. Latest version ($duckpan_module_version)" :
+				"You don't have $package installed. Installing latest version ($duckpan_module_version)";
 			$install_it = 1;
 		} elsif ($pin_version) {
 			$self->app->emit_info("$package: $localver installed, $pin_version pinned, $duckpan_module_version latest");
@@ -131,15 +131,15 @@ sub duckpan_install {
 					$reinstall  = 1;       # Let us roll back, if necessary. Multiple packages may confuse this, but little harm.
 					$install_it = 1;
 				} else {
-                    $message = "Could not locate version $pin_version of \'$package\'";
-                    $self->app->emit_and_exit(-1, $message);
+					$message = "Could not locate version $pin_version of \'$package\'";
+					$self->app->emit_and_exit(-1, $message);
 				}
 			} else {
-                $message = ($pin_version == $duckpan_module_version) ?
-                    "You already have the latest version of \'$package\' installed!" :
-                    "A newer version of \'$package\' exists. Please update your version pin to match the newest version: $duckpan_module_version";
-                $install_it = 0;
-            }
+				$message = ($pin_version == $duckpan_module_version) ?
+					"You already have the latest version of \'$package\' installed!" :
+					"A newer version of \'$package\' exists. Please update your version pin to match the newest version: $duckpan_module_version";
+				$install_it = 0;
+			}
 		} elsif ($localver == $duckpan_module_version) {
 			$message = "You already have latest version ($localver) of $package";
 		} elsif ($localver > $duckpan_module_version) {


### PR DESCRIPTION
This ensures that DuckPAN doesn't throw a fatal error when a new version of DuckPAN exists, but the user has the local version pin set lower. Instead it warns that a newer version exists and suggests that you update the local version pin.

Also fixed indentation inconsistencies in DuckPAN.pm and Perl.pm

/cc @zachthompson 