### PR TITLE
Enable utf8 flag in duckpan query

### DIFF
--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -89,9 +89,10 @@ sub _get_user_input {
 
 # Event that processes the query
 sub _run_query {
-    my ($k, $h, $query) = @_[KERNEL, HEAP, ARG0];    
-    
+    my ($k, $h, $query) = @_[KERNEL, HEAP, ARG0];
+
     my ($app, $blocks) = @$h{qw{app blocks}};
+    Encode::_utf8_on($query);
 
     try {
         my $request = DDG::Request->new(


### PR DESCRIPTION
In testing https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1264 I noticed some odd behaviour in DuckPAN when dealing with UTF8 chars in the regexs. When the regexes contain unicode chars (like 4 ÷ 2) and `use utf8` was **not** present, the IA did not work in DuckPAN Query but did in DuckPAN Server.

After seeing that DuckPAN Serve turns on the utf8 flag before passing the raw query to `DDG::Request` I tried that in DuckPAN Query and everything works as expected!

/cc @zachthompson 