### PR TITLE
Check DDG before installing bundles

### DIFF
--- a/bin/duckpan
+++ b/bin/duckpan
@@ -53,7 +53,8 @@ Commands include:
     poupload        Upload .po translations file to Duck.co
     publisher       Start local web server for DuckDuckGo-Publisher static websites
     query           Test Instant Answer triggers on command line
-    reinstall       Reinstall most recent DuckPAN and DDG Perl modules
+    reinstall       Reinstalls installed, pinned, or most recent DuckPAN and DDG Perl modules
+    latest          Like reintall but ignores installed versions
     release         Pushes a new release of the current project to duckpan.org
     roadrunner      Same as installdeps, but skips tests (dangerous!)
     server          Start local web server to test Instant Answer display
@@ -147,7 +148,11 @@ Upgrade DuckPAN and DDG to the latest versions.
 
 =item C<duckpan reinstall>
 
-Force installation of the latest released versions of DuckPAN and DDG.
+Force installation of DuckPAN and DDG modules using the installed, pinned, or latest versions, in that order.
+
+=item C<duckpan latest>
+
+Like L<reinstall> except it ignores any installed version.
 
 =item C<duckpan -I [filepath ...]>
 

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -292,13 +292,13 @@ sub execute {
 				elsif($m eq 'ddg' && $ddg){ next }
 				push @modules, $_;
 			}
-			elsif (m/^duckpan|update|(upgrade|reinstall)$/i) {
-				my $upgrade_reinstall = lc $1;
+			elsif (m/^duckpan|update|(upgrade|reinstall|latest)$/i) {
+				my ($all_modules, $reinstall_latest) = map { lc } ($1, $2);
 				$self->empty_cache unless $self->empty;
 				push @modules, 'App::DuckPAN';
-				if($upgrade_reinstall){
+				if($all_modules){
 					push @modules, 'DDG', map { "DDG::${_}Bundle::OpenSourceDuckDuckGo" } qw(Goodie Spice Fathead Longtail);
-					unshift @modules, 'reinstall' if $upgrade_reinstall eq 'reinstall';
+					unshift @modules, $reinstall_latest if $reinstall_latest; 
 				}
 			}
 			else {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -277,7 +277,7 @@ sub execute {
 				/^(ddg)$/i ||
 				/(opensourceduckduckgo)$/i ||
 				/^(goodie)$/i || /^(spice)$/i || /^(fathead)$/i || /^(longtail)$/i ||
-				/^ddg::/ ||
+				/^ddg::/i ||
 				/^app/i) {
 				my $m = lc $1;
 

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -276,16 +276,23 @@ sub execute {
 				/^dist/i ||
 				/^(ddg)$/i ||
 				/(opensourceduckduckgo)$/i ||
+				/^(goodie)$/i || /^(spice)$/ || /^(fathead)$/ || /^(longtail)$/ ||
 				/^app/i) {
 				my $m = lc $1;
+
+				if($m eq 'goodie' or $m eq 'spice' or $m eq 'fathead' or $m eq 'longtail'){
+					$_ = 'DDG::' . ucfirst($m) . 'Bundle::OpenSourceDuckDuckGo';
+					$m = 'opensourceduckduckgo';
+				}
+
 				if($m eq 'opensourceduckduckgo' && !$ddg){
 					unshift @modules, 'DDG';
-					++$ddg;
+					$ddg = 1;
 				}
 				elsif($m eq 'ddg' && $ddg){ next }
 				push @modules, $_;
 			}
-			elsif ($_ =~ m/^duckpan|update|(upgrade|reinstall)$/i) {
+			elsif (m/^duckpan|update|(upgrade|reinstall)$/i) {
 				my $upgrade_reinstall = lc $1;
 				$self->empty_cache unless $self->empty;
 				push @modules, 'App::DuckPAN';

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -277,6 +277,7 @@ sub execute {
 				/^(ddg)$/i ||
 				/(opensourceduckduckgo)$/i ||
 				/^(goodie)$/i || /^(spice)$/i || /^(fathead)$/i || /^(longtail)$/i ||
+				/^ddg::/ ||
 				/^app/i) {
 				my $m = lc $1;
 

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -276,7 +276,7 @@ sub execute {
 				/^dist/i ||
 				/^(ddg)$/i ||
 				/(opensourceduckduckgo)$/i ||
-				/^(goodie)$/i || /^(spice)$/ || /^(fathead)$/ || /^(longtail)$/ ||
+				/^(goodie)$/i || /^(spice)$/i || /^(fathead)$/i || /^(longtail)$/i ||
 				/^app/i) {
 				my $m = lc $1;
 

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -277,7 +277,7 @@ sub execute {
 				/^(ddg)$/i ||
 				/(opensourceduckduckgo)$/i ||
 				/^(goodie)$/i || /^(spice)$/i || /^(fathead)$/i || /^(longtail)$/i ||
-				/^ddg::/i ||
+				/^ddgc?::/i ||
 				/^app/i) {
 				my $m = lc $1;
 

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -92,10 +92,15 @@ sub cpanminus_install_error {
 sub duckpan_install {
 	my ($self, @modules) = @_;
 	my $mirror = $self->app->duckpan;
-	my $reinstall;
-	if ($modules[0] eq 'reinstall') {
+	my ($reinstall, $latest);
+	my $reinstall_latest = $modules[0];
+	if($reinstall_latest eq 'reinstall') {
 		# We sent in a signal to force reinstallation
 		$reinstall = 1;
+		shift @modules;
+	}
+	elsif($reinstall_latest eq 'latest') {
+		$latest = 1;
 		shift @modules;
 	}
 	my $packages = $self->app->duckpan_packages;
@@ -120,9 +125,11 @@ sub duckpan_install {
 		$self->app->emit_info("$package: $installed_version installed, $pinned_version pinned, $latest_version latest") if $pinned_version;
 
 		my ($install_it, $message);
-		if($reinstall || !$installed_version) {
+		if($reinstall || $latest || !$installed_version) {
 			# Prefer versions in the following order when (re)installing: installed, pinned, latest
-			my $version = $installed_version || $pinned_version || $latest_version;
+			# Latest ignores the installed version
+			my $version = $installed_version unless $latest;
+			$version ||= $pinned_version || $latest_version;
 			# update the url if not the latest
 			if($version != $latest_version){
 				unless($duckpan_module_url = $self->find_previous_url($module, $version)){

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -111,10 +111,10 @@ sub duckpan_install {
 		$sp =~ s/\:\:/_/g;
 
 		# special case: check for a pinned verison number
-		my $pinned_version		= $ENV{$sp};
-		my $installed_version	= $self->get_local_version($package);
-		my $latest_version		= version->parse($module->version);
-		my $duckpan_module_url	= $self->app->duckpan . 'authors/id/' . $module->distribution->pathname;
+		my $pinned_version      = $ENV{$sp};
+		my $installed_version   = $self->get_local_version($package);
+		my $latest_version      = version->parse($module->version);
+		my $duckpan_module_url  = $self->app->duckpan . 'authors/id/' . $module->distribution->pathname;
 
 		# Remind user about having pinned env variables
 		$self->app->emit_info("$package: $installed_version installed, $pinned_version pinned, $latest_version latest") if $pinned_version;
@@ -169,7 +169,7 @@ sub duckpan_install {
 
 	if(@to_install){
 		unshift @to_install, '--reinstall' if $reinstall;    # cpanm will do the actual forcing.
-		if(system "cpanm --fdfdfdfdfdf @to_install"){
+		if(system "cpanm @to_install"){
 			my $err = "cpanm failed (err $?) to (re)install the following modules:\n\n\t" .
 				join("\n\t", @to_install);
 			$self->app->emit_and_exit(-1, $err);


### PR DESCRIPTION
Adds DDG to list of packages to be checked when bundles are in play.  Currently doesn't do this and fails when installing a bundle directly or checking requirements.

Fixed a few bugs in DuckPAN::Perl, tried to clarify the what the versions really mean, and added a bit more error checking.
