### PR TITLE
DuckPAN: No bundles by default

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -420,7 +420,6 @@ sub check_requirements {
                         $self->check_perl &&
                         $self->check_app_duckpan &&
                         $self->check_ddg &&
-                        $self->check_ia_bundles &&
                         $self->check_ssh &&
                         $self->check_git);
         }

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -402,33 +402,6 @@ sub phrase_to_camel {
 	return join('', map { ucfirst $_; } (split /\s+/, $phrase));
 }
 
-sub check_requirements {
-	my ($self) = @_;
-
-	if (!$self->check) {
-		$self->emit_notice("Requirements checking was disabled...");
-		return 1;
-	}
-	my $signal_file = $self->cfg->cache_path->child('perl_checked');
-	my $last_checked_perl = ($signal_file->exists) ? $signal_file->stat->mtime : 0;
-	if ((time - $last_checked_perl) <= $self->cachesec) {
-		$self->emit_debug("Perl module versions recently checked, skipping requirements check...");
-	} else {
-		$self->emit_info("Checking for DuckPAN requirements...");
-
-		$self->emit_and_exit(1, 'Requirements check failed')
-		  unless (
-			$self->check_perl &&
-			$self->check_app_duckpan &&
-			$self->check_ddg &&
-			$self->check_ssh &&
-			$self->check_git);
-	}
-	$signal_file->touch;
-
-	return 1;
-}
-
 sub get_local_ddg_version {
 	my ( $self ) = @_;
 	return $self->perl->get_local_version('DDG');

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -279,6 +279,7 @@ sub execute {
 	if (@arr_args) {
 		my (@modules, @left_args, $ddg);
 		for (@arr_args) {
+			warn "arg: $_";
 			if (/^www/i ||
 				/^dist/i ||
 				/^(ddg)$/i ||
@@ -300,12 +301,12 @@ sub execute {
 				elsif($m eq 'ddg' && $ddg){ next }
 				push @modules, $_;
 			}
-			elsif (m/^duckpan|update|(upgrade|reinstall|latest)$/i) {
+			elsif (m/^duckpan|update|(upgrade|(reinstall|latest))$/i) {
 				my ($all_modules, $reinstall_latest) = map { lc } ($1, $2);
 				$self->empty_cache unless $self->empty;
 				push @modules, 'App::DuckPAN';
 				if($all_modules){
-					push @modules, 'DDG', map { "DDG::${_}Bundle::OpenSourceDuckDuckGo" } qw(Goodie Spice Fathead Longtail);
+					push @modules, 'DDG';
 					unshift @modules, $reinstall_latest if $reinstall_latest; 
 				}
 			}
@@ -420,7 +421,6 @@ sub check_requirements {
 			$self->check_perl &&
 			$self->check_app_duckpan &&
 			$self->check_ddg &&
-			$self->check_ia_bundles &&
 			$self->check_ssh &&
 			$self->check_git);
 	}

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -279,7 +279,6 @@ sub execute {
 	if (@arr_args) {
 		my (@modules, @left_args, $ddg);
 		for (@arr_args) {
-			warn "arg: $_";
 			if (/^www/i ||
 				/^dist/i ||
 				/^(ddg)$/i ||

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -130,6 +130,10 @@ sub duckpan_install {
 			# Latest ignores the installed version
 			my $version = $installed_version unless $latest;
 			$version ||= $pinned_version || $latest_version;
+			if($version == 9.999){
+				$self->app->emit_notice("You appear to be using a github repository for unversioned package $package...skipping");
+				next;
+			}
 			# update the url if not the latest
 			if($version != $latest_version){
 				unless($duckpan_module_url = $self->find_previous_url($module, $version)){

--- a/lib/App/DuckPAN/Perl.pm
+++ b/lib/App/DuckPAN/Perl.pm
@@ -131,7 +131,7 @@ sub duckpan_install {
 			my $version = $installed_version unless $latest;
 			$version ||= $pinned_version || $latest_version;
 			if($version == 9.999){
-				$self->app->emit_notice("You appear to be using a github repository for unversioned package $package...skipping");
+				$self->app->emit_notice("You appear to be using a GitHub repository for unversioned package $package...skipping");
 				next;
 			}
 			# update the url if not the latest


### PR DESCRIPTION
There is no requirement for IA bundles to be installed in the development environment.  This removes them from being automatically considered during requirements checking and when upgrading/reinstalling/latest.  They can still be installed and managed manually.

Also fixes a bug with the reinstall/latest commands.