### PR TITLE
* Add missing 'use strict; use warnings;' line

### DIFF
--- a/bin/duckpan
+++ b/bin/duckpan
@@ -2,6 +2,8 @@
 # PODNAME: duckpan
 # ABSTRACT: Command line tool for using the DuckPAN of DuckDuckGo
 
+use strict; use warnings;
+
 my @libs;
 
 BEGIN {

--- a/t/lib/DDG/Goodie/TwoShoes.pm
+++ b/t/lib/DDG/Goodie/TwoShoes.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::TwoShoes;
 
+use strict; use warnings;
 use DDG::Goodie;
 
 triggers start => //;

--- a/t/lib/DDG/Spice/NagaBhutJolokiaDax.pm
+++ b/t/lib/DDG/Spice/NagaBhutJolokiaDax.pm
@@ -1,5 +1,6 @@
 package DDG::Spice::NagaBhutJolokiaDax;
 
+use strict; use warnings;
 use DDG::Spice;
 
 triggers start => //;


### PR DESCRIPTION
Hi,

I propose fix to CPANTS warning regarding missing 'use strict; use warnings;' line.

Please review it.
Many Thanks.

Best Regards,
Mohammad S Anwar