### PR TITLE
Fix printing of failed to load instance answers

### DIFF
--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -6,7 +6,7 @@ with 'App::DuckPAN::HasApp';
 
 use Module::Pluggable::Object;
 use Class::Load ':all';
-use Data::Printer;
+use Data::Printer return_value => 'dump';
 use List::Util qw (first);
 
 sub get_dukgo_user_pass {

--- a/lib/App/DuckPAN/Query.pm
+++ b/lib/App/DuckPAN/Query.pm
@@ -2,7 +2,7 @@ package App::DuckPAN::Query;
 # ABSTRACT: Main application/loop for duckpan query
 
 use Moo;
-use Data::Printer;
+use Data::Printer return_value => 'dump';
 use POE qw( Wheel::ReadLine );
 use Try::Tiny;
 use open qw/:std :utf8/;

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -13,7 +13,7 @@ use Plack::MIME;
 use HTML::Entities;
 use HTML::TreeBuilder;
 use HTML::Element;
-use Data::Printer;
+use Data::Printer return_value => 'dump';
 use HTTP::Request;
 use LWP::UserAgent;
 use URI::Escape;


### PR DESCRIPTION
`p()`'s behaviour has changed in `Data::Printer >= 0.36` resulting in some unintended output. Specifically, it shows text such as `HASH(0x97d39e8)` after printing the list of instant answers that failed to load when starting `duckpan server`.

 This pull request is to work around this change in behaviour.

<s>Call emit_notice() on the return value of np() to fix the following.

- emit_notice() was called on the return value of p() from Data::Printer. Since
  this was a hashref, a superfluous string like HASH(0x97d39e8) was printed after
  the list of modules.
- p() printed to STDERR while emit_notice() printed to STDOUT.</s>