### PR TITLE
Fix ia_name_separated template variable

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -401,6 +401,23 @@ sub phrase_to_camel {
 	return join('', map { ucfirst $_; } (split /\s+/, $phrase));
 }
 
+# Guess the name of the instant answer from user input
+sub phrase_to_separated_name {
+    my ($self, $phrase) = @_;
+    my $separated_name = $phrase;
+
+    for ($separated_name) { # Set the context
+        # Capitalize words if there are no capital letters
+        s/\b([a-z])/\U$1/g         unless /[A-Z]/;
+        # Insert spaces at transitions to captial letters if there are no spaces
+        s/(?<=[^A-Z])(?=[A-Z])/ /g unless / /;
+        # Clear the package/path separators
+        s!(::|/)\s*! !g;
+    }
+
+    return $separated_name;
+}
+
 sub check_requirements {
         my ($self) = @_;
 

--- a/lib/App/DuckPAN/Cmd/New.pm
+++ b/lib/App/DuckPAN/Cmd/New.pm
@@ -29,8 +29,9 @@ sub run {
 	$self->app->emit_and_exit(-1, "Must supply a name for your Instant Answer.") unless $entered_name;
 	$entered_name =~ s/\//::/g;    #change "/" to "::" for easier handling
 	my $name = $self->app->phrase_to_camel($entered_name);
-	my ($package_name, $separated_name, $path, $lc_path) = ($name, $name, "", "");
-	$separated_name =~ s/::/ /g;
+	my ($package_name, $separated_name, $path, $lc_path) = ($name, "", "", "");
+
+	$separated_name = $self->app->phrase_to_separated_name($entered_name);
 
 	if ($entered_name =~ m/::/) {
 		my @path_parts = split(/::/, $entered_name);


### PR DESCRIPTION
It does it by guessing where to add spaces and which letters to capitalize. $entered_name is used as a base instead of $name since that should be more like what the user intends to name the instant answer.

Examples where it works well:
DuckDuckGo   -> Duck Duck Go # spaces before capitals
duck duck go -> Duck Duck Go # capitalize at word boundaries
perl 6       -> Perl 6       # ditto
iPad Apps    -> iPad Apps    # no change since spaces and capitals are already present
HTML 5       -> HTML 5       # ditto

Examples where it does not:
iPad         -> i Pad        # space added between 'i' and 'Pad'