### PR TITLE
Add alt_to values to rewrites

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -63,8 +63,15 @@ sub BUILD {
 			}
 			$share_dir_hash{$_->module_share_dir} = ref $_ if $_->can('module_share_dir');
 			$path_hash{$_->path} = ref $_ if $_->can('path');
+
+			my $alt_rewrites = $_->alt_rewrites;
+			while(my ($short_name, $rewrite) = each %$alt_rewrites){
+				$rewrite_hash{$short_name} = $rewrite;
+				$path_hash{$rewrite->path} = $short_name;
+			}
 		}
 	}
+
 	$self->_share_dir_hash(\%share_dir_hash);
 	$self->_path_hash(\%path_hash);
 	$self->_rewrite_hash(\%rewrite_hash);

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -60,15 +60,14 @@ sub BUILD {
 		for (@{$_->only_plugin_objs}) {
 			if ($_->does('DDG::IsSpice')) {
 				$rewrite_hash{ref $_} = $_->rewrite if $_->has_rewrite;
+				while(my ($short_name, $rewrite) = each %{$_->alt_rewrites}){
+					$rewrite_hash{$short_name} = $rewrite;
+					$path_hash{$rewrite->path} = $short_name;
+				}
 			}
 			$share_dir_hash{$_->module_share_dir} = ref $_ if $_->can('module_share_dir');
 			$path_hash{$_->path} = ref $_ if $_->can('path');
 
-			my $alt_rewrites = $_->alt_rewrites;
-			while(my ($short_name, $rewrite) = each %$alt_rewrites){
-				$rewrite_hash{$short_name} = $rewrite;
-				$path_hash{$rewrite->path} = $short_name;
-			}
 		}
 	}
 


### PR DESCRIPTION
Use the new [alt_rewrites](https://github.com/duckduckgo/duckduckgo/pull/163) method to obtain the `alt_to` links, if they exist from the parent.

Depends on https://github.com/duckduckgo/duckduckgo/pull/163