### PR TITLE
Set charset in Content-Type response header in duckpan publisher

### DIFF
--- a/lib/App/DuckPAN/WebPublisher.pm
+++ b/lib/App/DuckPAN/WebPublisher.pm
@@ -74,7 +74,7 @@ sub request {
 		$self->app->emit_info('Request '.$request->path_info.' uses '.$file.' from DDG::Publisher...');
 		$body = $site->fullpath_files->{$file}->uncached_content;
 		$response->code("200");
-		$response->content_type('text/html');
+		$response->content_type('text/html; charset=utf-8');
 	} else {
 		my $res = $self->app->http->request(HTTP::Request->new(GET => $url.$request->request_uri));
 		if ($res->is_success) {


### PR DESCRIPTION
Solves: https://github.com/duckduckgo/duckduckgo-publisher/issues/210

Why did it only affect donttrackus? Because the other sites declare charset [in a meta tag](https://github.com/duckduckgo/duckduckgo-publisher/blob/54fc865/share/site/dontbubbleus/head.tx#L3) and [donttrackus doesn't](https://github.com/duckduckgo/duckduckgo-publisher/blob/master/share/site/donttrackus/head.tx).

Since nginx or application servers in production do set the charset in the response headers, we haven't seen this issue live.

It's not an issue for static files proxied from dev instances, since the [content-type is set to be the same as the one sent by the server](https://github.com/duckduckgo/p5-app-duckpan/blob/fe04e3e/lib/App/DuckPAN/WebPublisher.pm#L83).

I think this change should be safe enough for the dev server, since we do not handle other charsets.