### PR TITLE
bin/duckpan: Fix Getopt::Long configuration

### DIFF
--- a/bin/duckpan
+++ b/bin/duckpan
@@ -16,6 +16,10 @@ BEGIN {
             map { try { $_->realpath } || $_->absolute } @missing) . "\n";
         exit 1;
     }
+
+    # For other commands, bundling is desirable but pass_through leads to
+    # incomplete validation of command line arguments
+    Getopt::Long::Configure('no_pass_through');
 }
 use lib @libs;
 


### PR DESCRIPTION
After processing switches to duckpan, disable 'pass_through' so that arguments
to other sub-commands get validated.

Before the fix:
```
$ duckpan server --option
Loading Instant Answers...
`DDG::Spice::--option' is not a module name

$ duckpan new --option
Created file: lib/DDG/Spice/--option.pm
Created file: share/spice/--option/--option.handlebars
Created file: share/spice/--option/--option.js
Created file: t/--option.t
Successfully created Spice: --option

```

After the fix:
```

$ duckpan server --option
Unknown option: option
USAGE: duckpan [-hp] [long options...]

    -p --port=Int  set port on which server should listen. defaults to 5000
                                                                        
    --usage        show a short help message
    -h             show a compact help message
    --help         show a long help message
    --man          show the manual

$ duckpan new --option

Unknown option: option
USAGE: duckpan [-h] [long options...]

                                                                        
    --usage  show a short help message
    -h       show a compact help message
    --help   show a long help message
    --man    show the manual

```