### PR TITLE
Fix camel casing of IA name containing path separators

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -396,9 +396,21 @@ sub camel_to_underscore {
 }
 
 sub phrase_to_camel {
- my ($self, $phrase) = @_;
-	# Other things imply camelCase, we're going with CamelCase, kinda.
-	return join('', map { ucfirst $_; } (split /\s+/, $phrase));
+	my ($self, $phrase) = @_;
+	my $camel = $phrase;
+
+	$camel =~ s/
+		(?:           # if a character:
+		      \s+     # - follows spaces
+		    | (?<=::) # - or follows ::
+		    | ^       # - or is the first character
+		)(.)          # (the character)
+		/\U$1/gx;     # then uppercase it (preceding spaces are removed)
+
+	# remove trailing spaces
+	$camel =~ s/\s+$//;
+
+	return $camel;
 }
 
 sub check_requirements {

--- a/lib/App/DuckPAN/Cmd/New.pm
+++ b/lib/App/DuckPAN/Cmd/New.pm
@@ -28,12 +28,14 @@ sub run {
 	my $entered_name = (@args) ? join(' ', @args) : $self->app->get_reply('Please enter a name for your Instant Answer: ');
 	$self->app->emit_and_exit(-1, "Must supply a name for your Instant Answer.") unless $entered_name;
 	$entered_name =~ s/\//::/g;    #change "/" to "::" for easier handling
-	my $name = $self->app->phrase_to_camel($entered_name);
-	my ($package_name, $separated_name, $path, $lc_path) = ($name, $name, "", "");
+
+	my $package_name = $self->app->phrase_to_camel($entered_name);
+	my ($name, $separated_name, $path, $lc_path) = ($package_name, $package_name, "", "");
+
 	$separated_name =~ s/::/ /g;
 
-	if ($entered_name =~ m/::/) {
-		my @path_parts = split(/::/, $entered_name);
+	if ($package_name =~ m/::/) {
+		my @path_parts = split(/::/, $package_name);
 		if (scalar @path_parts > 1) {
 			$name    = pop @path_parts;
 			$path    = join("/", @path_parts);

--- a/t/app_duckpan.t
+++ b/t/app_duckpan.t
@@ -30,6 +30,17 @@ is($app->perl->get_local_version('App::DuckPAN'),$version,'Checking get_local_ve
 ###############################################################
 isa_ok($app->cfg,'App::DuckPAN::Config');
 
+###############################################################
+# phrase_to_camel
+is $app->phrase_to_camel("DuckDuckGo"), "DuckDuckGo", "phrase to camel, from camel";
+is $app->phrase_to_camel("Duck Duck Go"), "DuckDuckGo", "phrase to camel, without case change";
+is $app->phrase_to_camel("duck duck Go"), "DuckDuckGo", "phrase to camel, with case changes";
+is $app->phrase_to_camel("duck    duckGo"), "DuckDuckGo", "phrase to camel, with variable spaces";
+is $app->phrase_to_camel("  duck duck Go  "), "DuckDuckGo", "phrase to camel, surrounded by spaces";
+is $app->phrase_to_camel("duck::duck::Go"), "Duck::Duck::Go", "phrase to camel, with package";
+is $app->phrase_to_camel("duck::duck Go"), "Duck::DuckGo", "phrase to camel, with package and space";
+
+###############################################################
 SKIP: {
 	skip "No DDG installed yet", 2 unless try_load_class('DDG');
 	my $ddg_version = $DDG::VERSION || '9.999';


### PR DESCRIPTION
([reference](https://github.com/srvsh/p5-app-duckpan/commit/4ca6147fb2f48d5bf8bd5cc8f92972ecb01043c0#commitcomment-14510228))

If the user enters a name containing path separators for an instant answer, camel casing can give incorrect results. Example:

```bash

$ duckpan new     # Expected: Hello::World, got Hello::world
Please enter a name for your Instant Answer: hello/world
Created file: lib/DDG/Goodie/hello/world.pm
Created file: t/hello/world.t
Successfully created Goodie: Hello::world

$ duckpan new     # Expected: Duck::DuckGo, got Duck::duckGo
Please enter a name for your Instant Answer: duck/duck go
Created file: lib/DDG/Goodie/duck/duck go.pm
Created file: t/duck/duck go.t
Successfully created Goodie: Duck::duckGo
```

This PR fixes the issue. The issue with the output file paths above containing spaces has also been fixed.