### PR TITLE
Generic templates: Add short options and fix bug to allow Perl package names in instant answers.

### DIFF
--- a/t/template/lib/DDG/Default.pm
+++ b/t/template/lib/DDG/Default.pm
@@ -1,2 +1,2 @@
 package <:$package_name:>;
-# <:$lia_name:>
+my $id = '<:$ia_id:>';

--- a/t/template/templates.yml
+++ b/t/template/templates.yml
@@ -16,27 +16,27 @@ templates:
     js:
         label:  Javascript
         input:  share/javascript/default.js
-        output: t/out/share/javascript/<:$lia_name:>.js
+        output: t/out/share/javascript/<:$ia_id:>.js
 
     css:
         label:  Javascript
         input:  share/css/default.css
-        output: t/out/share/css/<:$lia_name:>.css
+        output: t/out/share/css/<:$ia_id:>.css
 
     complex_out_dir:
         label:  README file
         input:  share/text/README
-        output: t/out/share/text/<:$lia_name:>/docs/README
+        output: t/out/share/text/<:$ia_id:>/docs/README
 
     no_input:
         label:  File with non-existent input
         input:  share/text/does_not_exist.txt
-        output: t/out/share/text/<:$lia_name:>.txt
+        output: t/out/share/text/<:$ia_id:>.txt
 
     no_write_perm:
         label:  Output directory is not writeable
         input:  share/text/README
-        output: t/out/readonly/<:$lia_name:>.txt
+        output: t/out/readonly/<:$ia_id:>.txt
 
 template_sets:
     all_optional:

--- a/t/templates.t
+++ b/t/templates.t
@@ -127,15 +127,15 @@ ok $template_set_map{subdir_support_not_defined}->subdir_support, 'Template set 
 ##################################
 
 my $package_name = 'MyInstantAnswer';
-my $lia_name = 'my_instant_answer';
+my $ia_id = 'my_instant_answer';
 my %vars = (
     package_name => $package_name,
-    lia_name     => $lia_name,
+    ia_id     => $ia_id,
 );
 my $pm_out_file   = "$TEMPLATE_OUT/lib/DDG/$package_name.pm";
 my $test_out_file = "$TEMPLATE_OUT/t/$package_name.test";
-my $js_out_file   = "$TEMPLATE_OUT/share/javascript/$lia_name.js";
-my $css_out_file  = "$TEMPLATE_OUT/share/css/$lia_name.css";
+my $js_out_file   = "$TEMPLATE_OUT/share/javascript/$ia_id.js";
+my $css_out_file  = "$TEMPLATE_OUT/share/css/$ia_id.css";
 
 clear_output_directory();
 
@@ -149,7 +149,7 @@ my $pm_file_content = path($pm_out_file)->slurp;
 # check the content of the output file using all variables
 is $pm_file_content, <<EOT, 'template: generated file content is as expected';
 package $package_name;
-# $lia_name
+my \$id = '$ia_id';
 EOT
 
 #########################################


### PR DESCRIPTION
Also renamed lia_name to ia_id in tests. These are to address @moollaza's suggestions in PR #279.

Changed Options:
    -l (short for --list-templates)
    -c (short for --template cheatsheet)
    -N or --no-optionals (to not ask questions about optional files)

Example session:

```bash
$ duckpan new -h ### Showing newly added options
USAGE: duckpan [-chlNt] [long options...]

    -c --cheatsheet       create a Cheat Sheet (short for `--template
                          cheatsheet'; valid only for Goodies)
    -l --list_templates   list the available instant answer templates and
                          exit
    -N --no_optionals     do not create any optional files from the chosen
                          template
    -t --template=String  template used to generate the instant answer
                          skeleton (default: default)

    --usage               show a short help message
    -h                    show a compact help message
    --help                show a long help message
    --man                 show the manual

$ duckpan new -N Git::Hub ### -N does not create any optional files
Creating a new Standard Goodie Instant Answer...
Created files:
    lib/DDG/Goodie/Git/Hub.pm
    t/Git/Hub.t
Success!

$ duckpan new Git:Hub ### Single colon is not allowed
Creating a new Standard Goodie Instant Answer...
[FATAL]  'Git:Hub' is not a valid name for an Instant Answer. Please run the program again and provide a valid name.

$ duckpan new -c random ### -c creates a cheat sheet
Creating a new Cheat Sheet Instant Answer...
Created files:
    share/goodie/cheat_sheets/json/random.json
Success!

$ duckpan new -c ### Trying to create a cheat sheet in the Spice repo
[FATAL]  Cheat Sheets can be created only in the Goodie Instant Answer repository.

```