### PR TITLE
Restart.pm: Don't use the 'needs_restart' fields from templates.yml file

### DIFF
--- a/lib/App/DuckPAN/Restart.pm
+++ b/lib/App/DuckPAN/Restart.pm
@@ -69,7 +69,7 @@ sub _get_directories_to_monitor {
 
         for my $template (@templates) {
             push @output_dirs, $template->output_directory
-                if $template->needs_restart;
+                unless $template->name =~ /test/;
         }
     } catch {
         if (/template definitions/i) {

--- a/lib/App/DuckPAN/Restart.pm
+++ b/lib/App/DuckPAN/Restart.pm
@@ -71,7 +71,8 @@ sub _get_directories_to_monitor {
             push @output_dirs, $template->output_directory
                 unless $template->name =~ /test/;
         }
-    } catch {
+    }
+    catch {
         if (/template definitions/i) {
             # There was a problem loading the template definitions file. This
             # can happen if the instant answer repository is of an older
@@ -90,7 +91,8 @@ sub _get_directories_to_monitor {
                 next if $type eq 'test'; # skip the test dir?
                 push @output_dirs, $io->{out};
             }
-        } else {
+        }
+        else {
             die $_;
         }
     };
@@ -104,8 +106,9 @@ sub _get_directories_to_monitor {
 
     ++$distinct_dirs{$self->app->get_ia_type()->{dir}};
 
-    return keys %distinct_dirs;
+    return [ keys %distinct_dirs ];
 }
+
 # Monitors development directories for file changes.  Tries to get the
 # list of directories in a general way.  This subroutine 
 # blocks, so when it returns we know there's been a change
@@ -116,12 +119,12 @@ sub _monitor_directories {
     # Note: Could potentially be functionality added to App::DuckPAN
     # which would return the directories involved in an IA
     # (see https://github.com/duckduckgo/p5-app-duckpan/issues/200)
-    my @dirs = $self->_get_directories_to_monitor;
+    my $dirs = $self->_get_directories_to_monitor;
 
     FSMON: while(1){
         # Find all subdirectories
         # Create our watcher with each directory
-        my $watcher = Filesys::Notify::Simple->new(\@dirs);
+        my $watcher = Filesys::Notify::Simple->new($dirs);
         # Wait for something to happen.  This blocks, which is why
         # it's in a wheel.  On detection of update it will fall
         # through; thus the while(1)

--- a/lib/App/DuckPAN/Template.pm
+++ b/lib/App/DuckPAN/Template.pm
@@ -57,12 +57,6 @@ sub _build_output_directory {
     return $out_dir;
 }
 
-has needs_restart => (
-    is       => 'ro',
-    required => 1,
-    doc      => 'Does the server need to be restarted when the output file is modified? (boolean)',
-);
-
 # Create the output file from the input file
 sub generate {
     my ($self, $vars) = @_;

--- a/lib/App/DuckPAN/TemplateDefinitions.pm
+++ b/lib/App/DuckPAN/TemplateDefinitions.pm
@@ -48,7 +48,6 @@ sub _build__template_map {
             label         => $template_data->{label},
             input_file    => path($template_root, $template_data->{input}),
             output_file   => path($template_data->{output}),
-            needs_restart => $template_data->{needs_restart},
         );
 
         $template_map{$name} = $template;

--- a/t/template/templates.yml
+++ b/t/template/templates.yml
@@ -4,7 +4,6 @@ templates:
         label:  Perl Module
         input:  lib/DDG/Default.pm
         output: t/out/lib/DDG/<:$package_name:>.pm
-        needs_restart: true
 
     test:
         label:  Perl Module Test

--- a/t/templates.t
+++ b/t/templates.t
@@ -75,8 +75,6 @@ is $template_map{pm}->input_file, 't/template/lib/DDG/Default.pm',
     'template defs: set template input field';
 is $template_map{pm}->output_file, 't/out/lib/DDG/<:$package_name:>.pm',
     'template defs: set template output field';
-ok $template_map{pm}->needs_restart,
-    'template defs: set template needs_restart field';
 
 # output directory computation
 is $template_map{pm}->output_directory, 't/out/lib/DDG',


### PR DESCRIPTION
When adding support for generic templates, I had added a `needs_restart` field to the `templates.yml` files for [Goodie](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/template/templates.yml#L15) and [Spice](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/template/templates.yml#L14) IAs to indicate which files (actually directories) should cause the server to restart when they are changed. The problem with that is that the `share/goodie` and `share/spice` directories are no longer watched for changes because no template-generated files in those directories (handlebars, css, js) need the server to be restarted. This is not right though, since now changes to other custom files such as config or data files of IAs do no cause a restart as well.

This PR reverts the 'needs_restart' change  and uses the old way of determining which directories to watch - basically all directories which contain auto-generated files, except for 'test' directories. I'll submit a couple of other PRs, one each for Goodie and Spice repositories to remove the field from the `templates.yml` files as well.

Thanks, and sorry about the error.

Testing steps:

1. Run `duckpan server` from a Goodie or Spice repository.
2. Create a new file in `share/`. The server will not restart.
3. Create or modifiy a file in `share/goodie` or `share/spice` or any subdirectory. The server will restart if the file has an extension other than `handlebars`, `css` or `js`.
4. Create or modify a file in `t/`. The server will not restart.