### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Developers have also been successful running DuckPAN on other Linux distros (e.g
 
 As well, **there have been reported issues with installing DuckPAN on Windows**, so we don't recommend you go down that path.
 
-That being said, we are more than willing to help you debug any installation problems, so please come to us with your problems and we'll try to get your issues sorted out. If you'd like some help from our community, feel free to engage with them on the [DuckDuckGo forum](http://duck.co/).
+That being said, we are more than willing to help you debug any installation problems, so please come to us with your problems and we'll try to get your issues sorted out. If you'd like some help from our community, feel free to engage with them on the [DuckDuckGo forum](https://duck.co/).
 
 
 ### Perl Versions
@@ -75,7 +75,7 @@ After installing DuckPAN, be sure to checkout the [Using DuckPAN](#using-duckpan
 2. Go to https://codio.com/duckduckgo/duckduckhack and fork the project. Make sure to fork the project and the box.
     ![Codio Fork](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckpan/assets/codio_fork.png)
     ![Codio Fork Both](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckpan/assets/codio_fork_both.png)
-3. Visit one of our Instant Answer repositories (such as https://github.com/duckduckgo/zeroclickinfo-spice), and follow GitHub's instructions to first [fork](https://help.github.com/articles/fork-a-repo) the repository. You can then clone the repo into your Codio machine (You need to open the Terminal for this).  
+3. Visit one of our Instant Answer repositories (such as https://github.com/duckduckgo/zeroclickinfo-spice), and follow GitHub's instructions to first [fork](https://help.github.com/articles/fork-a-repo/) the repository. You can then clone the repo into your Codio machine (You need to open the Terminal for this).  
     ![Codio Terminal](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckpan/assets/codio_terminal.png)
 4. Go into the directory (by typing in `cd zeroclickinfo-spice`) and run `duckpan server`. Click on "DuckPAN Server" to view the webpage.
     ![Codio Server](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckpan/assets/codio_server.png)
@@ -230,7 +230,7 @@ destroy  - Stop the currently running VM and blow everything away.
 
 Run these commands from the directory containing your `Vagrantfile`.
 
-For more information, please see the (excellent) [Vagrant docs](http://docs.vagrantup.com/).
+For more information, please see the (excellent) [Vagrant docs](https://www.vagrantup.com/docs/).
 
 ------
 
@@ -245,7 +245,7 @@ To install DuckPAN, open your terminal and run:
 curl http://duckpan.org/install.pl | perl
 ```
 
-[This script](https://github.com/duckduckgo/p5-duckpan-installer) will setup [local::lib](https://metacpan.org/module/local::lib), which is a way to install Perl modules without changing your base Perl installation. If you already use `local::lib` or [perlbrew](https://metacpan.org/module/perlbrew), don't worry, this script will intelligently use what you already have.
+[This script](https://github.com/duckduckgo/p5-duckpan-installer) will setup [local::lib](https://metacpan.org/pod/local::lib), which is a way to install Perl modules without changing your base Perl installation. If you already use `local::lib` or [perlbrew](https://metacpan.org/pod/perlbrew), don't worry, this script will intelligently use what you already have.
 
 If you didn't have a `local::lib` before running the install script, you will need to run the script twice. It should tell you when like this:
 
@@ -259,7 +259,7 @@ If everything works, you should see this at the end:
 EVERYTHING OK! You can now go hacking! :)
 ```
 
-Note that with `local::lib` now installed, you can easily install [Perl modules](http://search.cpan.org/) with [cpanm](https://metacpan.org/module/cpanm).
+Note that with `local::lib` now installed, you can easily install [Perl modules](http://search.cpan.org/) with [cpanm](https://metacpan.org/pod/cpanm).
 
 ```
 cpanm App::DuckPAN


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://duck.co/ | https://duck.co/ 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://docs.vagrantup.com/ | https://www.vagrantup.com/docs/ 
https://help.github.com/articles/fork-a-repo | https://help.github.com/articles/fork-a-repo/ 
https://metacpan.org/module/cpanm | https://metacpan.org/pod/cpanm 
https://metacpan.org/module/local::lib | https://metacpan.org/pod/local::lib 
https://metacpan.org/module/perlbrew | https://metacpan.org/pod/perlbrew 
