### PR TITLE
Add support for json as format parameter

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -266,6 +266,20 @@ sub request {
 		for (@{$self->blocks}) {
 			push(@results,$_->request($ddg_request));
 		}
+		if ($request->param('format') && $request->param('format') eq 'json') {
+				$response->content_type('application/x-javascript');
+				my %flattened = ();
+				if (defined $results[0]) {
+						my %result = %{$results[0]};
+						my $sa = delete $result{structured_answer};
+						%flattened = (%result, %{$sa});
+						$flattened{from} = $sa->{id};
+				};
+				my $result = %flattened ? \%flattened : '';
+				$body = to_json({ 'Answer' => $result }, { ascii => 1 });
+				$response->body($body);
+				return $response;
+		}
 
 		my $page = $self->page_spice;
 		my $uri_encoded_query = uri_escape_utf8($query, "^A-Za-z");


### PR DESCRIPTION
Can use 'format=json' to get a basic JSON response from DuckPAN server.

I'm essentially trying to imitate the `Answer` attribute, so that IAs in development can access the responses from a mocked API call.

Here is the response from `https://beta.duckduckgo.com/?format=json&q=2pi%2B7`:

![ddg-json-format-remote1](https://cloud.githubusercontent.com/assets/8598426/12695227/206a5730-c73f-11e5-9a31-aac166193417.png)

And from `http://localhost:5000/?format=json&q=2pi%2B7`:

![ddg-json-format-local1](https://cloud.githubusercontent.com/assets/8598426/12695234/3a4c53f6-c73f-11e5-97c5-46e6e00cec11.png)

And the invalid calls:

`https://beta.duckduckgo.com/?format=json&q=2pi%2B7h`:

![ddg-json-format-remote2](https://cloud.githubusercontent.com/assets/8598426/12695239/6cff3552-c73f-11e5-8e72-f677d4a4695b.png)

`http://localhost:5000/?format=json&q=2pi%2B7h`:


![ddg-json-format-local2](https://cloud.githubusercontent.com/assets/8598426/12695260/6d861b20-c740-11e5-96d3-23b132e32ea9.png)

