### PR TITLE
Allow user to use ID rather than name when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ install:
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl
 perl:
-  - '5.14'
   - '5.16'
-  - '5.18'
 script:
   - dzil smoke --release --author

--- a/dist.ini
+++ b/dist.ini
@@ -36,7 +36,6 @@ tag_format = %v
 push_to = origin master
 
 [AutoPrereqs]
-skip = ^DDG::
 
 [MetaNoIndex]
 directory = t/

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -427,11 +427,17 @@ sub phrase_to_camel {
 	return $camel;
 }
 
-sub _ia_names {
+has _ia_names => (
+	is      => 'ro',
+	lazy    => 1,
+	builder => '_build_ia_names',
+);
+
+sub _build_ia_names {
 	my $self = shift;
 	my @test_paths = File::Find::Rule->name('*.t')->in('t');
 	my @names = map { scalar(fileparse($_, qr/\.[^.]*/)) } @test_paths;
-	return @names;
+	return \@names;
 }
 
 # Normalize an Instant Answer name to a standard form.
@@ -440,8 +446,8 @@ sub normalize_ia_name {
 	my ($self, $name) = @_;
 	$name =~ s/_//g;
 	$name = lc $self->phrase_to_camel($name);
-	my @known_ias = $self->_ia_names();
-	return first { lc $_ eq $name } @known_ias;
+	my $known_ias = $self->_ia_names();
+	return first { lc $_ eq $name } @$known_ias;
 }
 
 sub check_requirements {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -9,6 +9,7 @@ use MooX::Options;
 use App::DuckPAN::Config;
 use File::Which;
 use File::Basename;
+use File::Find::Rule;
 use Class::Load ':all';
 use HTTP::Request::Common qw( GET POST );
 use HTTP::Status;

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -431,16 +431,21 @@ sub phrase_to_camel {
 
 # Normalize an Instant Answer name to a standard form.
 # Returns undef if an IA matching the given name cannot be found.
-sub normalize_ia_name {
+sub get_ia_by_name {
 	my ($self, $name) = @_;
-	my $ia = $name =~ /_/
-		? DDG::Meta::Data->get_ia(id => $name)
-		: DDG::Meta::Data->get_ia(id => $self->camel_to_underscore($name))
-		or $self->emit_and_exit(1, "No Instant Answer found with name '$name'");
-	my $mod_name = $ia->{perl_module};
-	$mod_name =~ /^DDG::(?:Goodie|Spice)(?:::[^:]+)*::([^:]+)$/
-		or $self->emit_and_exit(1, "Must be in the root of a checked-out Instant Answer repository to run DuckPAN");
-	return $1;
+	my $ia;
+	if ($name =~ /^DDG::/) {
+		$ia = DDG::Meta::Data->get_ia(module => $name);
+		$ia = $ia->[0] if $ia;
+	}
+	else {
+		$ia = $name =~ /_/
+			? DDG::Meta::Data->get_ia(id => $name)
+			: DDG::Meta::Data->get_ia(id => $self->camel_to_underscore($name));
+	}
+	$self->emit_and_exit(1, "No Instant Answer found with name '$name'")
+		unless defined $ia;
+	return $ia;
 }
 
 sub check_requirements {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -8,6 +8,7 @@ use MooX::Cmd;
 use MooX::Options;
 use App::DuckPAN::Config;
 use File::Which;
+use File::Basename;
 use Class::Load ':all';
 use HTTP::Request::Common qw( GET POST );
 use HTTP::Status;
@@ -424,6 +425,23 @@ sub phrase_to_camel {
 	$camel =~ s/\s+$//;
 
 	return $camel;
+}
+
+sub _ia_names {
+	my $self = shift;
+	my @test_paths = File::Find::Rule->name('*.t')->in('t');
+	my @names = map { scalar(fileparse($_, qr/\.[^.]*/)) } @test_paths;
+	return @names;
+}
+
+# Normalize an Instant Answer name to a standard form.
+# Returns undef if an IA matching the given name cannot be found.
+sub normalize_ia_name {
+	my ($self, $name) = @_;
+	$name =~ s/_//g;
+	$name = lc $self->phrase_to_camel($name);
+	my @known_ias = $self->_ia_names();
+	return first { lc $_ eq $name } @known_ias;
 }
 
 sub check_requirements {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -8,8 +8,6 @@ use MooX::Cmd;
 use MooX::Options;
 use App::DuckPAN::Config;
 use File::Which;
-use File::Basename;
-use File::Find::Rule;
 use Class::Load ':all';
 use HTTP::Request::Common qw( GET POST );
 use HTTP::Status;

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -25,7 +25,15 @@ sub run {
 	}
 	else {
 		my @to_test = ('t') unless @args;
+		my @test_paths = map { $_ =~ s#t/([^\.]+)(?:\.t)?+#$1#r } glob "t/*";
 		foreach my $ia (@args) {
+			if ($ia =~ /_|^[a-z]+$/) {
+				$ia =~ s/_//g;
+				$ia = lc $ia;
+				if (my @f = grep { lc $_ eq $ia } @test_paths) {
+					$ia = "@f";
+				}
+			}
 			if (-e "t/$ia.t") {
 				push @to_test, "t/$ia.t";
 			}

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -39,8 +39,7 @@ sub run {
 				push @cheat_sheet_tests, $ia;
 				next;
 			}
-			my $name = $self->app->normalize_ia_name($ia);
-			$ia = $name if $name;
+			$ia = $self->app->get_ia_by_name($ia)->{name};
 			if (-d "t/$ia") {
 				push @to_test, "t/$ia";
 			}

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -39,7 +39,10 @@ sub run {
 				push @cheat_sheet_tests, $ia;
 				next;
 			}
-			$ia = $self->app->get_ia_by_name($ia)->{name};
+			# Unfortunately we can't just use the name, because some have
+			# spaces - thus we grab the end of the package name.
+			$ia = $self->app->get_ia_by_name($ia)->{perl_module} =~ /::(\w+)$/;
+			$ia = $1;
 			if (-d "t/$ia") {
 				push @to_test, "t/$ia";
 			}

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -35,9 +35,8 @@ sub run {
 				next;
 			}
 			if ($ia =~ /_|^[a-z]+$/) {
-				$ia =~ s/_//g;
-				$ia = lc $ia;
-				if (my @f = grep { lc $_ eq $ia } @test_paths) {
+				my $name = lc $ia =~ s/_//gr;
+				if (my @f = grep { lc $_ eq $name } @test_paths) {
 					$ia = "@f";
 				}
 			}

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -26,7 +26,14 @@ sub run {
 	else {
 		my @to_test = ('t') unless @args;
 		my @test_paths = map { $_ =~ s#t/([^\.]+)(?:\.t)?+#$1#r } glob "t/*";
+		my @cheat_sheet_tests;
 		foreach my $ia (@args) {
+			if ($ia =~ /_cheat_sheet$/ && -d 't/CheatSheets') {
+				$ia =~ s/_cheat_sheet$//;
+				$ia =~ s/_/-/g;
+				push @cheat_sheet_tests, $ia;
+				next;
+			}
 			if ($ia =~ /_|^[a-z]+$/) {
 				$ia =~ s/_//g;
 				$ia = lc $ia;
@@ -44,7 +51,8 @@ sub run {
 				$self->app->emit_and_exit(1, "Could not find any tests for $ia");
 			}
 		};
-		$self->app->emit_error('Tests failed! See output above for details') if $ret = system("prove -lr @to_test");
+		$self->app->emit_error('Tests failed! See output above for details') if @to_test           and $ret = system("prove -lr @to_test");
+		$self->app->emit_error('Tests failed! See output above for details') if @cheat_sheet_tests and $ret = system("prove -lr t/CheatSheets/CheatSheetsJSON.t :: @cheat_sheet_tests");
 	}
 
 	return $ret;

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -17,6 +17,8 @@ option full => (
 sub run {
 	my ($self, @args) = @_;
 
+	my $ia_type = $self->app->get_ia_type->{name};
+
 	my $ret = 0;
 
 	if ($self->full) {
@@ -28,7 +30,9 @@ sub run {
 		my @test_paths = map { $_ =~ s#t/([^\.]+)(?:\.t)?+#$1#r } glob "t/*";
 		my @cheat_sheet_tests;
 		foreach my $ia (@args) {
-			if ($ia =~ /_cheat_sheet$/ && -d 't/CheatSheets') {
+			if ($ia =~ /_cheat_sheet$/) {
+				$self->app->emit_and_exit(1, 'Cheat sheets can only be tested in Goodies')
+					unless $ia_type eq 'Goodie';
 				$ia =~ s/_cheat_sheet$//;
 				$ia =~ s/_/-/g;
 				push @cheat_sheet_tests, $ia;

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -53,7 +53,11 @@ sub get_blocks_from_current_dir {
 	    } @args;
 	}
 	else {
-	    @args = map { $_ = "DDG::" . $type->{name} . "::$_" unless m,^lib(::|/)DDG,; $_; } @args;
+	    @args = map {
+				my $camel_name = $self->app->normalize_ia_name($_) || $_;
+				$camel_name =~ m,^lib(::|/)DDG, ? $camel_name
+					: 'DDG::' . $type->{name} . "::$camel_name";
+			} @args;
 	}
 	require lib;
 	lib->import('lib');

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -54,9 +54,7 @@ sub get_blocks_from_current_dir {
 	}
 	else {
 	    @args = map {
-				my $camel_name = $self->app->normalize_ia_name($_) || $_;
-				$camel_name =~ m,^lib(::|/)DDG, ? $camel_name
-					: 'DDG::' . $type->{name} . "::$camel_name";
+				my $camel_name = $self->app->get_ia_by_name($_)->{perl_module};
 			} @args;
 	}
 	require lib;


### PR DESCRIPTION
So you could do `duckpan test html_entities_decode` rather than `duckpan test HTMLEntitiesDecode`.

Also supports cheat sheets (in Goodies); so you could do `duckpan test vim_cheat_sheet`. Assuming duckduckgo/zeroclickinfo-goodies#2740 goes through, multiple cheat sheets could be specified.

### To-Do

- [x] Add special support for Cheat Sheets (so you could do `duckpan test vim_cheat_sheet`).