### PR TITLE
Update DuckPAN to use DDG.ready intead of run-on-ready class

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -445,8 +445,8 @@ sub request {
 			my $goodie = shift @calls_goodie;
 			$calls_nrj .= "DDG.duckbar.future_signal_tab({signal:'high',from:'$goodie->{id}'});",
 			# Uncomment following line and remove "setTimeout" line when javascript race condition is addressed
-			# $calls_script = q|<script type="text/JavaScript" class="script-run-on-ready">/*DDH.add(| . encode_json($goodie) . q|);*/</script>|;
-			$calls_script .= q|<script type="text/JavaScript" class="script-run-on-ready">/*window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100);*/</script>|;
+			# $calls_script = q|<script type="text/JavaScript">/*DDH.add(| . encode_json($goodie) . q|);*/</script>|;
+			$calls_script .= q|<script type="text/JavaScript">DDG.ready(function(){ window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100)});</script>|;
 		}
 		else{
 			$calls_nrj .= @calls_nrj ? join(';', map { "nrj('".$_."')" } @calls_nrj) . ';' : '';


### PR DESCRIPTION
We ditched the `script-run-on-ready` class internally for `DDG.ready()`. This updated DuckPAN accordingly to use that

/cc @bsstoner @andrey-p @zachthompson 