### PR TITLE
Fix dists.ini Git::NextVersion for new 4 digit tags

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,7 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 [@Basic]
 
 [Git::NextVersion]
-version_regexp = ^([0-9]+\.[0-9]+)$
+version_regexp = ^([0-9]+)$
 
 [PkgVersion]
 [MetaConfig]


### PR DESCRIPTION
This is required to create further release of DuckPAN with the correct release version