### PR TITLE
Add session caching to Web

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -80,6 +80,7 @@ sub run_psgi {
 }
 
 my $has_common_js = 0;
+my %session_cache;
 sub request {
 	my ( $self, $request ) = @_;
 	my $hostname = $self->server_hostname;
@@ -479,15 +480,31 @@ sub request {
 
 	}
 	else {
-		my $res = $self->ua->request(HTTP::Request->new(GET => "http://".$hostname.$request->request_uri));
-		if ($res->is_success) {
-			$body = $res->decoded_content;
-			$response->code($res->code);
-			$response->content_type($res->content_type);
+		my $uri = $request->request_uri;
+		if (exists $session_cache{$uri}) {
+			my $res = $session_cache{$uri};
+			$body = $res->{decoded_content};
+			$response->code($res->{code});
+			$response->content_type($res->{content_type});
 		}
 		else {
-			p($res->status_line, color => { string => 'red' });
-			$body = "";
+			my $res = $self->ua->request(
+				HTTP::Request->new(GET => "http://$hostname$uri")
+			);
+			if ($res->is_success) {
+				$body = $res->decoded_content;
+				$response->code($res->code);
+				$response->content_type($res->content_type);
+				$session_cache{$uri} = {
+					content_type    => $res->content_type,
+					code            => $res->code,
+					decoded_content => $res->decoded_content,
+				};
+			}
+			else {
+				p($res->status_line, color => { string => 'red' });
+				$body = "";
+			}
 		}
 	}
 


### PR DESCRIPTION
Certain assets such as `countries.json` and JavaScript dependencies were not being cached in `duckpan server`.

I've added caching to `App::DuckPAN::Web` to ensure that _within a single session_ (i.e, one load of `App::DuckPAN::Web`) the assets will not be requested more than once.

Load 1 (without caching): `17 requests, 1,666.72 KB, 26.09 s`.
Load 2 (without caching): `14 requests, 1,631.05 KB, 16.05 s`.
Load 3 (without caching): `14 requests, 1,631.05 KB, 16.37 s`.

Load 1 (with caching): `18 requests, 1,690.06 KB, 31.46 s`.
Load 2 (with caching): `14 requests, 1,631.05 KB 0.77 s`.
Load 3 (with caching): `14 requests, 1,631.05 KB, 0.81 s`.

My tests are a bit wacky, but in short: I had extreme delays before caching, with caching there is only a delay on the initial load. I have noticed no side-effects from caching.

/cc @jagtalon @moollaza @fzzr- (thought you might want to know).
