### PR TITLE
Allow duckpan to be run from anywhere within an Instant Answer repository

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -156,10 +156,11 @@ sub _build_ia_types {
 	my $ddg_path = path('lib', 'DDG');
 	my $t_dir = path('t');
 	return [{
-			name      => 'Goodie',
-			dir       => $ddg_path->child('Goodie'),
-			supported => 1,
-			templates => {
+			name          => 'Goodie',
+			dir           => $ddg_path->child('Goodie'),
+			supported     => 1,
+			path_basename => 'zeroclickinfo-goodies',
+			templates     => {
 				code => {
 					in  => path('template', 'lib', 'DDG', 'Goodie', 'Example.pm'),
 					out => $ddg_path->child('Goodie')
@@ -171,10 +172,11 @@ sub _build_ia_types {
 			},
 		},
 		{
-			name      => 'Spice',
-			dir       => $ddg_path->child('Spice'),
-			supported => 1,
-			templates => {
+			name          => 'Spice',
+			dir           => $ddg_path->child('Spice'),
+			supported     => 1,
+			path_basename => 'zeroclickinfo-spice',
+			templates     => {
 				code => {
 					in  => path('template', 'lib', 'DDG', 'Spice', 'Example.pm'),
 					out => $ddg_path->child('Spice')
@@ -194,14 +196,16 @@ sub _build_ia_types {
 			},
 		},
 		{
-			name      => 'Fathead',
-			dir       => $ddg_path->child('Fathead'),
-			supported => 0
+			name          => 'Fathead',
+			dir           => $ddg_path->child('Fathead'),
+			supported     => 0,
+			path_basename => 'zeroclickinfo-fathead',
 		},
 		{
-			name      => 'Longtail',
-			dir       => $ddg_path->child('Longtail'),
-			supported => 0
+			name          => 'Longtail',
+			dir           => $ddg_path->child('Longtail'),
+			supported     => 0,
+			path_basename => 'zeroclickinfo-longtail',
 		},
 	];
 }
@@ -624,6 +628,51 @@ sub empty_cache {
 	$self->emit_info("Emptying DuckPAN cache...");
 	$cache->remove_tree({keep_root => 1});
 	$self->emit_info("DuckPAN cache emptied");
+}
+
+has repository => (
+	is  => 'rwp',
+	doc => 'Instant Answer repository from which DuckPAN was run.',
+	trigger => \&_check_repository,
+);
+
+sub _get_repository_config {
+	my ($self, $by, $lookup, $single) = @_;
+	$single //= 0;
+	my @repos = grep { $_->{$by} eq $lookup } @{$self->ia_types};
+	$single ? (@repos > 1 ? undef : $repos[0]) : @repos;
+}
+
+sub _check_repository {
+	my ($self, $repo) = @_;
+	my $path_basename = $repo->{path_basename};
+	$self->emit_and_exit(-1,
+		"'$path_basename' is currently not supported by DuckPAN."
+	) unless $repo->{supported};
+}
+
+# Ensure further commands are run from the 'root' of the Instant
+# Answer repository.
+sub initialize_working_directory {
+	my $self = shift;
+	my $check_path = Path::Tiny::cwd;
+	while (!$check_path->is_rootdir()) {
+		if (my $repo = $self->_get_repository_config(
+				path_basename => $check_path->basename, 1
+			)) {
+			$self->_set_repository($repo);
+			chdir $check_path->stringify;
+			last;
+		}
+	}
+	continue {
+		$check_path = $check_path->parent;
+	}
+	unless ($self->repository) {
+		$self->emit_and_exit(-1,
+			'Must be run from within an Instant Answer repository'
+		);
+	}
 }
 
 sub BUILD {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -612,13 +612,7 @@ sub checking_dukgo_user {
 
 sub get_ia_type {
 	my ($self) = @_;
-
-	my $ia_type = first { $_->{dir}->is_dir } @{$self->ia_types};
-
-	$self->emit_and_exit(-1, 'Must be run from the root of a checked-out Instant Answer repository.') unless ($ia_type);
-	$self->emit_and_exit(-1, "Sorry, DuckPAN does not support " . $ia_type->{name} . " yet!") if $ia_type->{supported} == 0;
-
-	return $ia_type;
+	return $self->repository;
 }
 
 sub empty_cache {

--- a/lib/App/DuckPAN/Cmd.pm
+++ b/lib/App/DuckPAN/Cmd.pm
@@ -9,10 +9,16 @@ has app => (
 	is => 'rw',
 );
 
+sub initialize {
+	my $self = shift;
+	$self->app->initialize_working_directory();
+}
+
 sub execute {
 	my ( $self, $args, $chain ) = @_;
 	my $app = shift @{$chain};
 	$self->app($app);
+	$self->initialize();
 	$self->run(@{$args});
 }
 

--- a/lib/App/DuckPAN/Cmd/Global.pm
+++ b/lib/App/DuckPAN/Cmd/Global.pm
@@ -1,0 +1,12 @@
+package App::DuckPAN::Cmd::Global;
+# ABSTRACT: Commands that can be run from anywhere.
+
+use Moo::Role;
+
+with qw( App::DuckPAN::Cmd );
+
+around initialize => sub { return; };
+
+1;
+
+__END__

--- a/lib/App/DuckPAN/Cmd/Help.pm
+++ b/lib/App/DuckPAN/Cmd/Help.pm
@@ -2,12 +2,10 @@ package App::DuckPAN::Cmd::Help;
 # ABSTRACT: Launch help page
 
 use Moo;
-with qw( App::DuckPAN::Cmd );
+with qw( App::DuckPAN::Cmd::Global );
 
 use MooX::Options protect_argv => 0;
 use Pod::Usage qw(pod2usage);
-
-sub initialize { return };
 
 sub run {
 	my ($self, $short_output) = @_;

--- a/lib/App/DuckPAN/Cmd/Help.pm
+++ b/lib/App/DuckPAN/Cmd/Help.pm
@@ -7,6 +7,8 @@ with qw( App::DuckPAN::Cmd );
 use MooX::Options protect_argv => 0;
 use Pod::Usage qw(pod2usage);
 
+sub initialize { return };
+
 sub run {
 	my ($self, $short_output) = @_;
 

--- a/lib/App/DuckPAN/Cmd/Help.pm
+++ b/lib/App/DuckPAN/Cmd/Help.pm
@@ -2,7 +2,7 @@ package App::DuckPAN::Cmd::Help;
 # ABSTRACT: Launch help page
 
 use Moo;
-with qw( App::DuckPAN::Cmd::Global );
+with qw( App::DuckPAN::Option::Global );
 
 use MooX::Options protect_argv => 0;
 use Pod::Usage qw(pod2usage);

--- a/lib/App/DuckPAN/Option/Global.pm
+++ b/lib/App/DuckPAN/Option/Global.pm
@@ -1,4 +1,4 @@
-package App::DuckPAN::Cmd::Global;
+package App::DuckPAN::Option::Global;
 # ABSTRACT: Commands that can be run from anywhere.
 
 use Moo::Role;


### PR DESCRIPTION
Rather than failing whenever DuckPAN is run from within an Instant Answer repository, but not the root, we *find* the correct root then use that as the working directory for the remaining commands.

Fixes #255

/cc @zachthompson @moollaza 