### PR TITLE
Ensure Restart doesn't exit DuckPAN forcefully

### DIFF
--- a/lib/App/DuckPAN/Cmd/Query.pm
+++ b/lib/App/DuckPAN/Cmd/Query.pm
@@ -10,8 +10,7 @@ use MooX::Options protect_argv => 0;
 
 sub run {
 	my ($self, @args) = @_;
-
-	exit $self->run_restarter(\@args);
+	$self->run_restarter(\@args);
 }
 
 sub _run_app {

--- a/lib/App/DuckPAN/Restart.pm
+++ b/lib/App/DuckPAN/Restart.pm
@@ -24,7 +24,7 @@ sub run_restarter {
 	    defined(my $app = fork) or die 'Failed to fork application';
 	    unless($app){ # app kid
 	        $self->_run_app($args);
-	        exit 0;
+	        return;
 	    }
 
 	    # Slightly different format here since we need to take care of
@@ -36,7 +36,7 @@ sub run_restarter {
 	            die 'Failed to fork file monitor';
 	        }
 	        $self->_monitor_directories;
-	        exit 0;
+	        return;
 	    }
 
 	    # wait for one them to exit. -1 waits for all children
@@ -53,7 +53,7 @@ sub run_restarter {
 	    }
 	    elsif($pid == $app){ # or exit
 	        kill SIGTERM => $fmon;
-	        exit;
+	        return;
 	    }
 	    else{ die "Unknown kid $pid reaped!\n"; } # shouldn't happen
 	}


### PR DESCRIPTION
There are cases (like with Console - pending) where we don't want duckpan to exit
immediately, but rather we would like to return to a menu; now we may do
so.

Basically this ensures we can run Query as a sub-command.

/cc @zachthompson 