### PR TITLE
Add Lookup Role

### DIFF
--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -1,7 +1,6 @@
 package App::DuckPAN::Lookup;
 # ABSTRACT: Role for standardized lookups.
 
-use List::Util qw(pairs);
 use App::DuckPAN::Lookup::Util;
 
 use Moo::Role;

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -2,16 +2,7 @@ package App::DuckPAN::Lookup;
 # ABSTRACT: Role for standardized lookups.
 
 use List::Util qw(pairs);
-
-sub satisfy {
-	my ($parent, $by, $lookup) = @_;
-	if (ref $by eq 'CODE') {
-		return $by->($parent, $lookup);
-	}
-	my $pby = ref $parent eq 'HASH'
-		? $parent->{$by} : $parent->$by;
-	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
-}
+use App::DuckPAN::Lookup::Util;
 
 use Moo::Role;
 
@@ -21,16 +12,9 @@ requires '_lookup_id';
 
 sub lookup {
 	my ($self, @lookups) = @_;
-	my @items = @{$self->_lookup()};
-	return @items unless @lookups;
-	my %results;
-	my $id = $self->_lookup_id();
-	foreach (pairs @lookups) {
-		my ($by, $lookup) = @$_;
-		map { $results{$_->{$id}} = $_ }
-			grep { satisfy($_, $by, $lookup) } @items;
-	}
-	return values %results;
+	return App::DuckPAN::Lookup::Util::lookup(
+		$self->_lookup(), $self->_lookup_id(), @lookups,
+	);
 }
 
 1;

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -7,13 +7,11 @@ use App::DuckPAN::Lookup::Util;
 use Moo::Role;
 
 requires '_lookup';
-# Unique value that can be used to distinguish lookup items.
-requires '_lookup_id';
 
 sub lookup {
 	my ($self, @lookups) = @_;
 	return App::DuckPAN::Lookup::Util::lookup(
-		$self->_lookup(), $self->_lookup_id(), @lookups,
+		$self->_lookup(), @lookups,
 	);
 }
 

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -1,0 +1,38 @@
+package App::DuckPAN::Lookup;
+# ABSTRACT: Role for standardized lookups.
+
+use List::Util qw(pairs);
+
+sub satisfy {
+	my ($parent, $by, $lookup) = @_;
+	if (ref $by eq 'CODE') {
+		return $by->($parent, $lookup);
+	}
+	my $pby = ref $parent eq 'HASH'
+		? $parent->{$by} : $parent->$by;
+	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
+}
+
+use Moo::Role;
+
+requires '_lookup';
+# Unique value that can be used to distinguish lookup items.
+requires '_lookup_id';
+
+sub lookup {
+	my ($self, @lookups) = @_;
+	my @items = @{$self->_lookup()};
+	return @items unless @lookups;
+	my %results;
+	my $id = $self->_lookup_id();
+	foreach (pairs @lookups) {
+		my ($by, $lookup) = @$_;
+		map { $results{$_->{$id}} = $_ }
+			grep { satisfy($_, $by, $lookup) } @items;
+	}
+	return values %results;
+}
+
+1;
+
+__END__

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -13,12 +13,9 @@ use List::Util qw(pairs);
 
 sub satisfy {
 	my ($parent, $by, $lookup) = @_;
-	if (ref $by eq 'CODE') {
-		return $by->($parent, $lookup);
-	}
 	my $pby = ref $parent eq 'HASH'
 		? $parent->{$by} : $parent->$by;
-	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
+	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;
 }
 
 sub lookup {

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -20,15 +20,14 @@ sub satisfy {
 
 sub lookup {
 	my ($lookup_vals, $lookup_id, @lookups) = @_;
-	my @items = @$lookup_vals;
-	return @items unless @lookups;
-	my %results;
+	my %results = map { $_->{$lookup_id} => $_ } @$lookup_vals;
+	my @results = values %results;
 	foreach (pairs @lookups) {
+		return () unless @results;
 		my ($by, $lookup) = @$_;
-		map { $results{$_->{$lookup_id}} = $_ }
-			grep { satisfy($_, $by, $lookup) } @items;
+		@results = grep { satisfy($_, $by, $lookup) } @results;
 	}
-	return values %results;
+	return @results;
 }
 
 1;

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -10,6 +10,7 @@ BEGIN {
 }
 
 use List::Util qw(pairs);
+use List::MoreUtils qw(uniq);
 
 sub satisfy {
 	my ($parent, $by, $lookup) = @_;
@@ -19,9 +20,8 @@ sub satisfy {
 }
 
 sub lookup {
-	my ($lookup_vals, $lookup_id, @lookups) = @_;
-	my %results = map { $_->{$lookup_id} => $_ } @$lookup_vals;
-	my @results = values %results;
+	my ($lookup_vals, @lookups) = @_;
+	my @results = uniq @$lookup_vals;
 	foreach (pairs @lookups) {
 		return () unless @results;
 		my ($by, $lookup) = @$_;

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -14,6 +14,7 @@ use List::MoreUtils qw(uniq);
 
 sub satisfy {
 	my ($parent, $by, $lookup) = @_;
+	return $by->($parent, $lookup) if ref $by eq 'CODE';
 	my $pby = ref $parent eq 'HASH'
 		? $parent->{$by} : $parent->$by;
 	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -1,0 +1,39 @@
+package App::DuckPAN::Lookup::Util;
+# ABSTRACT: Utilities for standardized lookups.
+
+BEGIN {
+	require Exporter;
+
+	our @ISA = qw(Exporter);
+
+	our @EXPORT_OK = qw(lookup);
+}
+
+use List::Util qw(pairs);
+
+sub satisfy {
+	my ($parent, $by, $lookup) = @_;
+	if (ref $by eq 'CODE') {
+		return $by->($parent, $lookup);
+	}
+	my $pby = ref $parent eq 'HASH'
+		? $parent->{$by} : $parent->$by;
+	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
+}
+
+sub lookup {
+	my ($lookup_vals, $lookup_id, @lookups) = @_;
+	my @items = @$lookup_vals;
+	return @items unless @lookups;
+	my %results;
+	foreach (pairs @lookups) {
+		my ($by, $lookup) = @$_;
+		map { $results{$_->{$lookup_id}} = $_ }
+			grep { satisfy($_, $by, $lookup) } @items;
+	}
+	return values %results;
+}
+
+1;
+
+__END__

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Deep;
+use App::DuckPAN::Lookup::Util qw(lookup);
+
+my $foo = {
+	id          => 'foo',
+	description => 'A metasyntactic variable',
+	foo_or_bar  => 1,
+	numeric     => 0,
+};
+
+my $bar = {
+	id          => 'bar',
+	description => 'A metasyntactic variable',
+	foo_or_bar  => 1,
+	numeric     => 1,
+};
+
+my $baz = {
+	id          => 'baz',
+	description => 'A metasyntactic variable',
+	foo_or_bar  => 0,
+	numeric     => 2,
+};
+
+my $lookups = [ $foo, $bar, $baz ];
+
+my $lookup_id = 'id';
+
+subtest 'lookup' => sub {
+	my $look = sub { lookup($lookups, $lookup_id, @_) };
+	cmp_deeply([$look->()], bag(@$lookups), 'no lookups specified');
+	subtest 'single lookup' => sub {
+		my @id = $look->(id => 'foo');
+		cmp_deeply(\@id, [$foo], 'lookup with unique key');
+		my @desc = $look->(description => 'A metasyntactic variable');
+		cmp_deeply(\@desc, bag($foo, $bar, $baz), 'lookup with non-unique key');
+		my @gte1 = $look->(numeric => sub { $_[0] >= 1 });
+		cmp_deeply(\@gte1, bag($bar, $baz), 'with $by as a subroutine');
+	};
+	subtest 'multi lookup' => sub {
+		my @foo_bar_baz = $look->(id => 'baz', foo_or_bar => 1);
+		cmp_deeply(\@foo_bar_baz, bag($foo, $bar, $baz), 'lookup that should include everything');
+	};
+};
+
+done_testing;
+
+1;
+
+__END__

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -38,7 +38,9 @@ subtest 'lookup' => sub {
 		my @desc = $look->(description => 'A metasyntactic variable');
 		cmp_deeply(\@desc, bag($foo, $bar, $baz), 'lookup with non-unique key');
 		my @gte1 = $look->(numeric => sub { $_[0] >= 1 });
-		cmp_deeply(\@gte1, bag($bar, $baz), 'with $by as a subroutine');
+		cmp_deeply(\@gte1, bag($bar, $baz), 'with $lookup as a subroutine');
+		my @by_sub = $look->(sub { $_[0]->{numeric} >= $_[1] } => 1);
+		cmp_deeply(\@by_sub, bag($bar, $baz), 'with $by as a subroutine');
 	};
 	subtest 'multi lookup' => sub {
 		my @foo_bar_baz = $look->(id => 'bar', foo_or_bar => 1);

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -29,10 +29,8 @@ my $baz = {
 
 my $lookups = [ $foo, $bar, $baz ];
 
-my $lookup_id = 'id';
-
 subtest 'lookup' => sub {
-	my $look = sub { lookup($lookups, $lookup_id, @_) };
+	my $look = sub { lookup($lookups, @_) };
 	cmp_deeply([$look->()], bag(@$lookups), 'no lookups specified');
 	subtest 'single lookup' => sub {
 		my @id = $look->(id => 'foo');

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -43,8 +43,12 @@ subtest 'lookup' => sub {
 		cmp_deeply(\@gte1, bag($bar, $baz), 'with $by as a subroutine');
 	};
 	subtest 'multi lookup' => sub {
-		my @foo_bar_baz = $look->(id => 'baz', foo_or_bar => 1);
-		cmp_deeply(\@foo_bar_baz, bag($foo, $bar, $baz), 'lookup that should include everything');
+		my @foo_bar_baz = $look->(id => 'bar', foo_or_bar => 1);
+		cmp_deeply(\@foo_bar_baz, [$bar], 'with overlapping values');
+		my @id_foo_bar = $look->(id => 'foo', id => 'bar');
+		cmp_deeply(\@id_foo_bar, [], 'with 2 unique keys');
+		my @desc_foo_bar = $look->(description => 'A metasyntactic variable', foo_or_bar => 1);
+		cmp_deeply(\@desc_foo_bar, bag($foo, $bar), 'with overlapping values (multiple)');
 	};
 };
 


### PR DESCRIPTION
This role will allow us to have consistent lookup operations across Templates, Sets, InstantAnswers, Repositories etc.

Pulled out of #335 - in which `Template::Set`, `Template::Definitions`, `InstantAnswer::Repo` etc. make use of it.

/cc @zachthompson 