### PR TITLE
Add InstantAnswer Utilities

### DIFF
--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -99,11 +99,16 @@ sub find_ia_files {
 	} else {
 		# Back-end files
 		my $ddg_path = _path_from_package($ia->{perl_module});
+		my $back_end_base = $ia->{perl_module} =~ s/^DDG::[^:]+:://r;
+		my $back_end_separated = _path_from_package($back_end_base);
 		my $back_end_module = path('lib', "${ddg_path}.pm");
 		$back_end_module = undef unless $back_end_module->exists;
 		my $back_end_dir = path('lib', $ddg_path);
+		my $test_file = path('t', "$back_end_separated.t");
+		$test_file = undef unless $test_file->exists;
 		my @other_back_end = File::Find::Rule->name('*')->in($back_end_dir);
 		$named{back_end_module} = $back_end_module;
+		$named{test} = $test_file,
 		push @other, @other_back_end;
 		# Share files
 		push @other, File::Find::Rule->name('*')

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -10,11 +10,14 @@ BEGIN {
 		predicate => [qw(is_cheat_sheet is_spice
 											is_goodie is_full_goodie)],
 	);
-	our @EXPORT_OK = (qw(find_ia_files), map { @$_ } values %EXPORT_TAGS);
+	our @EXPORT_OK = (qw(find_ia_files get_ia), map { @$_ } values %EXPORT_TAGS);
 }
 
 use Path::Tiny;
 use File::Find::Rule;
+
+use DDG::Meta::Data;
+use App::DuckPAN::Lookup::Util;
 
 # Repo, but make sure there is no 's' on the end.
 sub _share_repo {
@@ -123,6 +126,12 @@ sub find_ia_files {
 		all   => \@all,
 		other => \@other,
 	);
+}
+
+my $ias = [values DDG::Meta::Data->by_id()];
+
+sub get_ia {
+	App::DuckPAN::Lookup::Util::lookup($ias, q(id), @_);
 }
 
 1;

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -147,7 +147,7 @@ sub find_ia_files {
 my $ias = [values DDG::Meta::Data->by_id()];
 
 sub get_ia {
-	App::DuckPAN::Lookup::Util::lookup($ias, q(id), @_);
+	App::DuckPAN::Lookup::Util::lookup($ias, @_);
 }
 
 1;

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -7,8 +7,10 @@ BEGIN {
 	our @ISA = qw(Exporter);
 
 	our %EXPORT_TAGS = (
-		predicate => [qw(is_cheat_sheet is_spice
-											is_goodie is_full_goodie)],
+		predicate => [qw(
+			is_cheat_sheet is_spice
+			is_goodie is_full_goodie
+		)],
 	);
 	our @EXPORT_OK = (qw(find_ia_files get_ia), map { @$_ } values %EXPORT_TAGS);
 }

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -6,7 +6,10 @@ BEGIN {
 
 	our @ISA = qw(Exporter);
 
-	our @EXPORT_OK = qw(find_ia_files is_cheat_sheet);
+	our %EXPORT_TAGS = (
+		predicate => [qw(is_cheat_sheet is_spice is_goodie)],
+	);
+	our @EXPORT_OK = (qw(find_ia_files), map { @$_ } values %EXPORT_TAGS);
 }
 
 use Path::Tiny;
@@ -47,6 +50,16 @@ sub repo_paths {
 sub is_cheat_sheet {
 	my $ia = shift;
 	return $ia->{id} =~ /_cheat_sheet$/;
+}
+
+sub is_goodie {
+	my $ia = shift;
+	return $ia->{repo} eq 'goodies';
+}
+
+sub is_spice {
+	my $ia = shift;
+	return $ia->{repo} eq 'spice';
 }
 
 # Find the file for a cheat sheet given the metadata.

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -7,7 +7,8 @@ BEGIN {
 	our @ISA = qw(Exporter);
 
 	our %EXPORT_TAGS = (
-		predicate => [qw(is_cheat_sheet is_spice is_goodie)],
+		predicate => [qw(is_cheat_sheet is_spice
+											is_goodie is_full_goodie)],
 	);
 	our @EXPORT_OK = (qw(find_ia_files), map { @$_ } values %EXPORT_TAGS);
 }
@@ -55,6 +56,11 @@ sub is_cheat_sheet {
 sub is_goodie {
 	my $ia = shift;
 	return $ia->{repo} eq 'goodies';
+}
+
+sub is_full_goodie {
+	my $ia = shift;
+	return is_goodie($ia) && !is_cheat_sheet($ia);
 }
 
 sub is_spice {

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -90,10 +90,10 @@ sub find_ia_files {
 		push @other, File::Find::Rule->name('*')
 			->in($meta_paths{local_share});
 	}
-	%named = map { $_ => $named{$_} } grep { $named{$_} } (keys %named);
-	@other = grep { $_ } @other;
+	%named = map { $_ => path($named{$_}) } grep { $named{$_} } (keys %named);
+	@other = map { path($_) } grep { $_ } @other;
 	my %n = map { $_ => 1 } grep { $_ } (@other, values %named);
-	@all = keys %n;
+	@all = map { path($_) } keys %n;
 	return (
 		named => \%named,
 		all   => \@all,

--- a/lib/App/DuckPAN/InstantAnswer/Util.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Util.pm
@@ -1,0 +1,106 @@
+package App::DuckPAN::InstantAnswer::Util;
+# ABSTRACT: Utilities for working with Instant Answer Metadata.
+
+BEGIN {
+	require Exporter;
+
+	our @ISA = qw(Exporter);
+
+	our @EXPORT_OK = qw(find_ia_files is_cheat_sheet);
+}
+
+use Path::Tiny;
+use File::Find::Rule;
+
+# Repo, but make sure there is no 's' on the end.
+sub _share_repo {
+	my $repo = shift;
+	return lc ($repo =~ s/s$//ir);
+}
+
+sub _lib_repo { ucfirst _share_repo(shift) }
+
+# Currently hard-coded as we know where they all are.
+my $cheat_dir = path('share/goodie/cheat_sheets/json');
+
+# Repository-specific paths that can be derived from metadata.
+sub repo_paths {
+	my $ia = shift;
+	# Goodie/Spice etc.
+	my $lib_repo = _lib_repo($ia->{repo});
+	# goodie/spice etc.
+	my $share_name = _share_repo($ia->{repo});
+	my $back_end_dir = path("lib/DDG/$lib_repo");
+	my $share_dir = path("share/$share_name");
+	my $local_share = path($share_dir, $ia->{id});
+	if (is_cheat_sheet($ia) eq 'cheat_sheet') {
+		$local_share = $share_dir->child('cheat_sheets');
+	}
+	return (
+		share           => $share_dir,
+		local_share     => $local_share,
+		# Location of Instant Answer back-end packages
+		back_end_dir    => $back_end_dir,
+	);
+}
+
+sub is_cheat_sheet {
+	my $ia = shift;
+	return $ia->{id} =~ /_cheat_sheet$/;
+}
+
+# Find the file for a cheat sheet given the metadata.
+sub find_cheat_sheet {
+	my $ia = shift;
+	my $fname = $ia->{id} =~ s/_cheat_sheet$//r;
+	$fname =~ s/_/-/g;
+	$fname .= '.json';
+	return File::Find::Rule->name($fname)->in($cheat_dir);
+}
+
+sub _path_from_package {
+	my $package = shift;
+	return $package =~ s{::}{/}gr;
+}
+
+# Find all *existing* files for an Instant Answer.
+sub find_ia_files {
+	my $ia = shift;
+	# All files found.
+	my @all;
+	# Files found that aren't 'special' (named).
+	my @other;
+	# 'Special' files.
+	my %named;
+	my %meta_paths = repo_paths($ia);
+	if (is_cheat_sheet($ia)) {
+		my ($cheat_file, @other_cheats) = find_cheat_sheet($ia);
+		$named{cheat_sheet} = $cheat_file;
+		push @other, @other_cheats;
+	} else {
+		# Back-end files
+		my $ddg_path = _path_from_package($ia->{perl_module});
+		my $back_end_module = path('lib', "${ddg_path}.pm");
+		$back_end_module = undef unless $back_end_module->exists;
+		my $back_end_dir = path('lib', $ddg_path);
+		my @other_back_end = File::Find::Rule->name('*')->in($back_end_dir);
+		$named{back_end_module} = $back_end_module;
+		push @other, @other_back_end;
+		# Share files
+		push @other, File::Find::Rule->name('*')
+			->in($meta_paths{local_share});
+	}
+	%named = map { $_ => $named{$_} } grep { $named{$_} } (keys %named);
+	@other = grep { $_ } @other;
+	my %n = map { $_ => 1 } grep { $_ } (@other, values %named);
+	@all = keys %n;
+	return (
+		named => \%named,
+		all   => \@all,
+		other => \@other,
+	);
+}
+
+1;
+
+__END__

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -1,7 +1,6 @@
 package App::DuckPAN::Lookup;
 # ABSTRACT: Role for standardized lookups.
 
-use List::Util qw(pairs);
 use App::DuckPAN::Lookup::Util;
 
 use Moo::Role;

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -2,16 +2,7 @@ package App::DuckPAN::Lookup;
 # ABSTRACT: Role for standardized lookups.
 
 use List::Util qw(pairs);
-
-sub satisfy {
-	my ($parent, $by, $lookup) = @_;
-	if (ref $by eq 'CODE') {
-		return $by->($parent, $lookup);
-	}
-	my $pby = ref $parent eq 'HASH'
-		? $parent->{$by} : $parent->$by;
-	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
-}
+use App::DuckPAN::Lookup::Util;
 
 use Moo::Role;
 
@@ -21,16 +12,9 @@ requires '_lookup_id';
 
 sub lookup {
 	my ($self, @lookups) = @_;
-	my @items = @{$self->_lookup()};
-	return @items unless @lookups;
-	my %results;
-	my $id = $self->_lookup_id();
-	foreach (pairs @lookups) {
-		my ($by, $lookup) = @$_;
-		map { $results{$_->{$id}} = $_ }
-			grep { satisfy($_, $by, $lookup) } @items;
-	}
-	return values %results;
+	return App::DuckPAN::Lookup::Util::lookup(
+		$self->_lookup(), $self->_lookup_id(), @lookups,
+	);
 }
 
 1;

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -7,13 +7,11 @@ use App::DuckPAN::Lookup::Util;
 use Moo::Role;
 
 requires '_lookup';
-# Unique value that can be used to distinguish lookup items.
-requires '_lookup_id';
 
 sub lookup {
 	my ($self, @lookups) = @_;
 	return App::DuckPAN::Lookup::Util::lookup(
-		$self->_lookup(), $self->_lookup_id(), @lookups,
+		$self->_lookup(), @lookups,
 	);
 }
 

--- a/lib/App/DuckPAN/Lookup.pm
+++ b/lib/App/DuckPAN/Lookup.pm
@@ -1,0 +1,38 @@
+package App::DuckPAN::Lookup;
+# ABSTRACT: Role for standardized lookups.
+
+use List::Util qw(pairs);
+
+sub satisfy {
+	my ($parent, $by, $lookup) = @_;
+	if (ref $by eq 'CODE') {
+		return $by->($parent, $lookup);
+	}
+	my $pby = ref $parent eq 'HASH'
+		? $parent->{$by} : $parent->$by;
+	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
+}
+
+use Moo::Role;
+
+requires '_lookup';
+# Unique value that can be used to distinguish lookup items.
+requires '_lookup_id';
+
+sub lookup {
+	my ($self, @lookups) = @_;
+	my @items = @{$self->_lookup()};
+	return @items unless @lookups;
+	my %results;
+	my $id = $self->_lookup_id();
+	foreach (pairs @lookups) {
+		my ($by, $lookup) = @$_;
+		map { $results{$_->{$id}} = $_ }
+			grep { satisfy($_, $by, $lookup) } @items;
+	}
+	return values %results;
+}
+
+1;
+
+__END__

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -13,12 +13,9 @@ use List::Util qw(pairs);
 
 sub satisfy {
 	my ($parent, $by, $lookup) = @_;
-	if (ref $by eq 'CODE') {
-		return $by->($parent, $lookup);
-	}
 	my $pby = ref $parent eq 'HASH'
 		? $parent->{$by} : $parent->$by;
-	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
+	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;
 }
 
 sub lookup {

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -20,15 +20,14 @@ sub satisfy {
 
 sub lookup {
 	my ($lookup_vals, $lookup_id, @lookups) = @_;
-	my @items = @$lookup_vals;
-	return @items unless @lookups;
-	my %results;
+	my %results = map { $_->{$lookup_id} => $_ } @$lookup_vals;
+	my @results = values %results;
 	foreach (pairs @lookups) {
+		return () unless @results;
 		my ($by, $lookup) = @$_;
-		map { $results{$_->{$lookup_id}} = $_ }
-			grep { satisfy($_, $by, $lookup) } @items;
+		@results = grep { satisfy($_, $by, $lookup) } @results;
 	}
-	return values %results;
+	return @results;
 }
 
 1;

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -10,6 +10,7 @@ BEGIN {
 }
 
 use List::Util qw(pairs);
+use List::MoreUtils qw(uniq);
 
 sub satisfy {
 	my ($parent, $by, $lookup) = @_;
@@ -19,9 +20,8 @@ sub satisfy {
 }
 
 sub lookup {
-	my ($lookup_vals, $lookup_id, @lookups) = @_;
-	my %results = map { $_->{$lookup_id} => $_ } @$lookup_vals;
-	my @results = values %results;
+	my ($lookup_vals, @lookups) = @_;
+	my @results = uniq @$lookup_vals;
 	foreach (pairs @lookups) {
 		return () unless @results;
 		my ($by, $lookup) = @$_;

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -14,6 +14,7 @@ use List::MoreUtils qw(uniq);
 
 sub satisfy {
 	my ($parent, $by, $lookup) = @_;
+	return $by->($parent, $lookup) if ref $by eq 'CODE';
 	my $pby = ref $parent eq 'HASH'
 		? $parent->{$by} : $parent->$by;
 	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;

--- a/lib/App/DuckPAN/Lookup/Util.pm
+++ b/lib/App/DuckPAN/Lookup/Util.pm
@@ -1,0 +1,39 @@
+package App::DuckPAN::Lookup::Util;
+# ABSTRACT: Utilities for standardized lookups.
+
+BEGIN {
+	require Exporter;
+
+	our @ISA = qw(Exporter);
+
+	our @EXPORT_OK = qw(lookup);
+}
+
+use List::Util qw(pairs);
+
+sub satisfy {
+	my ($parent, $by, $lookup) = @_;
+	if (ref $by eq 'CODE') {
+		return $by->($parent, $lookup);
+	}
+	my $pby = ref $parent eq 'HASH'
+		? $parent->{$by} : $parent->$by;
+	ref $pby eq 'CODE' ? $pby->($lookup) : $pby eq $lookup;
+}
+
+sub lookup {
+	my ($lookup_vals, $lookup_id, @lookups) = @_;
+	my @items = @$lookup_vals;
+	return @items unless @lookups;
+	my %results;
+	foreach (pairs @lookups) {
+		my ($by, $lookup) = @$_;
+		map { $results{$_->{$lookup_id}} = $_ }
+			grep { satisfy($_, $by, $lookup) } @items;
+	}
+	return values %results;
+}
+
+1;
+
+__END__

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Deep;
+use App::DuckPAN::Lookup::Util qw(lookup);
+
+my $foo = {
+	id          => 'foo',
+	description => 'A metasyntactic variable',
+	foo_or_bar  => 1,
+	numeric     => 0,
+};
+
+my $bar = {
+	id          => 'bar',
+	description => 'A metasyntactic variable',
+	foo_or_bar  => 1,
+	numeric     => 1,
+};
+
+my $baz = {
+	id          => 'baz',
+	description => 'A metasyntactic variable',
+	foo_or_bar  => 0,
+	numeric     => 2,
+};
+
+my $lookups = [ $foo, $bar, $baz ];
+
+my $lookup_id = 'id';
+
+subtest 'lookup' => sub {
+	my $look = sub { lookup($lookups, $lookup_id, @_) };
+	cmp_deeply([$look->()], bag(@$lookups), 'no lookups specified');
+	subtest 'single lookup' => sub {
+		my @id = $look->(id => 'foo');
+		cmp_deeply(\@id, [$foo], 'lookup with unique key');
+		my @desc = $look->(description => 'A metasyntactic variable');
+		cmp_deeply(\@desc, bag($foo, $bar, $baz), 'lookup with non-unique key');
+		my @gte1 = $look->(numeric => sub { $_[0] >= 1 });
+		cmp_deeply(\@gte1, bag($bar, $baz), 'with $by as a subroutine');
+	};
+	subtest 'multi lookup' => sub {
+		my @foo_bar_baz = $look->(id => 'baz', foo_or_bar => 1);
+		cmp_deeply(\@foo_bar_baz, bag($foo, $bar, $baz), 'lookup that should include everything');
+	};
+};
+
+done_testing;
+
+1;
+
+__END__

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -38,7 +38,9 @@ subtest 'lookup' => sub {
 		my @desc = $look->(description => 'A metasyntactic variable');
 		cmp_deeply(\@desc, bag($foo, $bar, $baz), 'lookup with non-unique key');
 		my @gte1 = $look->(numeric => sub { $_[0] >= 1 });
-		cmp_deeply(\@gte1, bag($bar, $baz), 'with $by as a subroutine');
+		cmp_deeply(\@gte1, bag($bar, $baz), 'with $lookup as a subroutine');
+		my @by_sub = $look->(sub { $_[0]->{numeric} >= $_[1] } => 1);
+		cmp_deeply(\@by_sub, bag($bar, $baz), 'with $by as a subroutine');
 	};
 	subtest 'multi lookup' => sub {
 		my @foo_bar_baz = $look->(id => 'bar', foo_or_bar => 1);

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -29,10 +29,8 @@ my $baz = {
 
 my $lookups = [ $foo, $bar, $baz ];
 
-my $lookup_id = 'id';
-
 subtest 'lookup' => sub {
-	my $look = sub { lookup($lookups, $lookup_id, @_) };
+	my $look = sub { lookup($lookups, @_) };
 	cmp_deeply([$look->()], bag(@$lookups), 'no lookups specified');
 	subtest 'single lookup' => sub {
 		my @id = $look->(id => 'foo');

--- a/t/Lookup.t
+++ b/t/Lookup.t
@@ -43,8 +43,12 @@ subtest 'lookup' => sub {
 		cmp_deeply(\@gte1, bag($bar, $baz), 'with $by as a subroutine');
 	};
 	subtest 'multi lookup' => sub {
-		my @foo_bar_baz = $look->(id => 'baz', foo_or_bar => 1);
-		cmp_deeply(\@foo_bar_baz, bag($foo, $bar, $baz), 'lookup that should include everything');
+		my @foo_bar_baz = $look->(id => 'bar', foo_or_bar => 1);
+		cmp_deeply(\@foo_bar_baz, [$bar], 'with overlapping values');
+		my @id_foo_bar = $look->(id => 'foo', id => 'bar');
+		cmp_deeply(\@id_foo_bar, [], 'with 2 unique keys');
+		my @desc_foo_bar = $look->(description => 'A metasyntactic variable', foo_or_bar => 1);
+		cmp_deeply(\@desc_foo_bar, bag($foo, $bar), 'with overlapping values (multiple)');
 	};
 };
 


### PR DESCRIPTION
Provides utilities for:

* Checking the type of Instant Answer (Spice, Goodie, Cheat Sheet etc.)

* Finds InstantAnswer files based on metadata (it'll get most things - but it'd be better if some of these were provided in the metadata directly).

* Provides a metadata lookup (see duckduckgo/duckduckgo#195 for an implementation that we would be able to use instead).

Depends on: #342 (or at least, supersedes it).

/cc @zachthompson 