### PR TITLE
Add InstantAnswer::Config

### DIFF
--- a/lib/App/DuckPAN/InstantAnswer/Config.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Config.pm
@@ -26,6 +26,11 @@ sub _build_files {
 	return \%files;
 }
 
+sub is_configured {
+	my $self = shift;
+	return @{$self->files->{all}} ? 1 : 0;
+}
+
 $Data::Dumper::Terse = 1;
 sub for_display {
 	my ($self, $item) = @_;

--- a/lib/App/DuckPAN/InstantAnswer/Config.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Config.pm
@@ -8,10 +8,10 @@ use App::DuckPAN::InstantAnswer::Util qw(find_ia_files is_cheat_sheet);
 
 use Data::Dumper;
 
-has ia => (
+has meta => (
 	is       => 'ro',
-	doc      => 'Instant Answer being configured.',
 	required => 1,
+	doc      => 'Instant Answer Metadata',
 );
 
 has files => (
@@ -22,7 +22,7 @@ has files => (
 
 sub _build_files {
 	my $self = shift;
-	my %files = find_ia_files($self->ia);
+	my %files = find_ia_files($self->meta);
 	return \%files;
 }
 

--- a/lib/App/DuckPAN/InstantAnswer/Config.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Config.pm
@@ -15,7 +15,7 @@ has ia => (
 );
 
 has files => (
-	is      => 'ro',
+	is      => 'rwp',
 	builder => 1,
 	lazy    => 1,
 );
@@ -30,6 +30,11 @@ $Data::Dumper::Terse = 1;
 sub for_display {
 	my ($self, $item) = @_;
 	return Dumper($item);
+}
+
+sub refresh {
+	my $self = shift;
+	$self->_set_files($self->_build_files);
 }
 
 1;

--- a/lib/App/DuckPAN/InstantAnswer/Config.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Config.pm
@@ -1,0 +1,29 @@
+package App::DuckPAN::InstantAnswer::Config;
+# ABSTRACT: Holds meta information about an Instant Answer being
+# configured.
+
+use Moo;
+
+use App::DuckPAN::InstantAnswer::Util qw(find_ia_files);
+
+has ia => (
+	is       => 'ro',
+	doc      => 'Instant Answer being configured.',
+	required => 1,
+);
+
+has files => (
+	is      => 'ro',
+	builder => 1,
+	lazy    => 1,
+);
+
+sub _build_files {
+	my $self = shift;
+	my %files = find_ia_files($self->ia);
+	return \%files;
+}
+
+1;
+
+__END__

--- a/lib/App/DuckPAN/InstantAnswer/Config.pm
+++ b/lib/App/DuckPAN/InstantAnswer/Config.pm
@@ -4,7 +4,9 @@ package App::DuckPAN::InstantAnswer::Config;
 
 use Moo;
 
-use App::DuckPAN::InstantAnswer::Util qw(find_ia_files);
+use App::DuckPAN::InstantAnswer::Util qw(find_ia_files is_cheat_sheet);
+
+use Data::Dumper;
 
 has ia => (
 	is       => 'ro',
@@ -22,6 +24,12 @@ sub _build_files {
 	my $self = shift;
 	my %files = find_ia_files($self->ia);
 	return \%files;
+}
+
+$Data::Dumper::Terse = 1;
+sub for_display {
+	my ($self, $item) = @_;
+	return Dumper($item);
 }
 
 1;


### PR DESCRIPTION
This provides a wrapper around the metadata from the platform; allowing us to provide additional information and operations that aren't present in the metadata.

Depends on #343.

/cc @zachthompson