### PR TITLE
Add 'debug' flag as an alias for 'verbose'

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -82,7 +82,7 @@ option colors => (
 option verbose => (
 	is      => 'ro',
 	lazy    => 1,
-	short   => 'v',
+	short   => 'v|debug',
 	default => sub { 0 },
 	doc     => 'provide expanded output during operation',
 );


### PR DESCRIPTION
Fixes #222 as we can now use '--debug' as a flag.

/cc @zachthompson 