### PR TITLE
Use Carp for error messages

### DIFF
--- a/lib/App/DuckPAN/Restart.pm
+++ b/lib/App/DuckPAN/Restart.pm
@@ -6,6 +6,7 @@ use Filesys::Notify::Simple;
 
 use App::DuckPAN::TemplateDefinitions;
 use Try::Tiny;
+use Carp;
 
 use strict;
 
@@ -21,7 +22,7 @@ sub run_restarter {
 
 	# will keep (re)starting the server until the app exits
 	while(1){
-	    defined(my $app = fork) or die 'Failed to fork application';
+	    defined(my $app = fork) or croak('Failed to fork application');
 	    unless($app){ # app kid
 	        $self->_run_app($args);
 	        exit 0;
@@ -33,7 +34,7 @@ sub run_restarter {
 	    unless($fmon){ # file monitor kid
 	        unless(defined $fmon){
 	            kill SIGTERM => $app;
-	            die 'Failed to fork file monitor';
+	            croak('Failed to fork file monitor');
 	        }
 	        $self->_monitor_directories;
 	        exit 0;
@@ -46,7 +47,7 @@ sub run_restarter {
 	    if($pid == $fmon){
 	        # if we can't kill the app, let's not start another
 	        unless(kill SIGTERM => $app){
-	            die "Failed to kill the application (pid: $app). Check manually";
+	            croak("Failed to kill the application (pid: $app). Check manually");
 	        }
 	        # wait for it, otherwise the next whie loop will get it
 	        waitpid($app, 0);
@@ -55,7 +56,7 @@ sub run_restarter {
 	        kill SIGTERM => $fmon;
 	        exit;
 	    }
-	    else{ die "Unknown kid $pid reaped!\n"; } # shouldn't happen
+	    else{ croak("Unknown kid $pid reaped!\n"); } # shouldn't happen
 	}
 }
 
@@ -93,7 +94,7 @@ sub _get_directories_to_monitor {
 	        }
 	    }
 	    else {
-	        die $_;
+	        croak($_);
 	    }
 	};
 

--- a/lib/App/DuckPAN/Template.pm
+++ b/lib/App/DuckPAN/Template.pm
@@ -73,7 +73,7 @@ sub generate {
 	# actual path here
 	my $output_file = path($tx->render_string($self->output_file, $vars));
 
-	carp("Template output file $output_file already exists") and return if $output_file->exists;
+	croak("Template output file $output_file already exists") and return if $output_file->exists;
 
 	my $content = $tx->render($input_file, $vars);
 

--- a/lib/App/DuckPAN/Template.pm
+++ b/lib/App/DuckPAN/Template.pm
@@ -9,6 +9,7 @@ use Moo;
 use Try::Tiny;
 use Text::Xslate;
 use Path::Tiny qw(path);
+use Carp;
 
 use namespace::clean;
 
@@ -72,14 +73,14 @@ sub generate {
 	# actual path here
 	my $output_file = path($tx->render_string($self->output_file, $vars));
 
-	die "Template output file '" . $output_file . "' already exists" if $output_file->exists;
+	carp("Template output file $output_file already exists") and return if $output_file->exists;
 
 	my $content = $tx->render($input_file, $vars);
 
 	try {
 	    path($output_file)->touchpath->spew_utf8($content);
 	} catch {
-	    die "Error creating output file '$output_file' from template: $_";
+	    croak "Error creating output file '$output_file' from template: $_";
 	};
 
 	return $output_file;

--- a/lib/App/DuckPAN/TemplateSet.pm
+++ b/lib/App/DuckPAN/TemplateSet.pm
@@ -14,6 +14,7 @@ use Moo;
 use Try::Tiny;
 use List::Util qw(all);
 use Algorithm::Combinatorics qw(combinations);
+use Carp;
 
 use namespace::clean;
 
@@ -120,7 +121,7 @@ sub generate {
 
 	# Verify that $optional_templates has templates from within $self->optional_templates
 	$self->_are_templates_optional(@$optional_templates)
-		or die "Unknown template(s) in \$optional_templates";
+		or croak("Unknown template(s) in \$optional_templates");
 
 	for my $template (@{$self->required_templates}, @$optional_templates) {
 		try {

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -152,7 +152,7 @@ sub request {
 				$path_remainder =~ s/^\///;
 				my $spice_class = $self->_path_hash->{$_};
 				$rewrite = $self->_rewrite_hash->{$spice_class};
-				die "Spice tested here must have a rewrite..." unless $rewrite;
+				croak("Spice tested here must have a rewrite...") unless $rewrite;
 				my $from = $rewrite->from;
 				my $re = $rewrite->has_from ? qr{$from} : qr{(.*)};
 				if (my @captures = $path_remainder =~ m/$re/) {
@@ -377,8 +377,8 @@ sub request {
 					}
 					else{ # auto-template
 						my $input_size = @{$structured->{input}};
-						die "Auto-templating with input of size $input_size called for '$structured->{operation}', "
-							. "while only sizes up to 2 are supported" if $input_size >= 3;
+						croak("Auto-templating with input of size $input_size called for '$structured->{operation}', "
+							. "while only sizes up to 2 are supported") if $input_size >= 3;
 						my $template_name = 'goodie_'.$input_size.'_inputs';
 						my $json_string = encode_json({Answer => $structured});
 						$zci_container->push_content(HTML::TreeBuilder->new_from_content("<script>\$(window).load(function(){"

--- a/lib/App/DuckPAN/WebStatic.pm
+++ b/lib/App/DuckPAN/WebStatic.pm
@@ -31,7 +31,7 @@ sub BUILD {
 		my $port = $self->sites->{$site}->{port};
 		my $url = $self->sites->{$site}->{url};
 		my $data_file = path($site.'.json');
-		die "Missing JSON publisher data file for ".$site unless $data_file->is_file;
+		croak("Missing JSON publisher data file for $site") unless $data_file->is_file;
 		my $data = decode_json($data_file->slurp_utf8);
 		my %urls;
 		for my $dir (keys %$data) {


### PR DESCRIPTION
Carp provides better error messages than just 'die' or 'warn'; this switches use of 'die' and 'warn' to 'croak' and 'carp' respectively.

/cc @zachthompson 