### PR TITLE
Don't require DDG::Publisher to be installed

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,7 @@ tag_format = %v
 push_to = origin master
 
 [AutoPrereqs]
+skip = ^DDG::Publisher
 
 [MetaNoIndex]
 directory = t/


### PR DESCRIPTION
Removing `skip=^DDG::` meant that installing DuckPAN tried to install `DDG::Publisher` which is non-essential and not on CPAN

We still need `DDG::Meta::Data` though so hopefully this suffices both conditions

/cc @zachthompson 