### PR TITLE
Check post_body is defined before modifying

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -164,7 +164,7 @@ sub request {
 						my $cap_to = $captures[$index];
 						if (defined $cap_to) {
 							$to =~ s/$cap_from/$cap_to/g;
-							$post_body =~ s/$cap_from/$cap_to/g;
+							$post_body =~ s/$cap_from/$cap_to/g if $post_body;
 						}
 						else {
 							$to =~ s/$cap_from//g;


### PR DESCRIPTION
It looks like on Codio (Perl 5.18) the line I've adjusted sees `$post_body` as uninitialized. I wasn't able to figure out why exactly that is. I couldn't determine any other cause so I assume its due to Perl 5.18?

Checking it's defined-ness seems to fix.

/cc @jbarrett @zachthompson 

![codio_-_duckduckhack](https://cloud.githubusercontent.com/assets/873785/16523359/064f45c2-3f71-11e6-857b-456256c2feb5.png)
