### PR TITLE
Add template var for cheat sheet file names

### DIFF
--- a/lib/App/DuckPAN/Cmd/New.pm
+++ b/lib/App/DuckPAN/Cmd/New.pm
@@ -212,6 +212,12 @@ sub run {
 		ia_path_lc        => $lc_filepath,
 	);
 
+	# Cheat sheets use hyphenated file names.
+	if ($self->template eq 'cheatsheet') {
+		my $underscored = $vars{ia_id} =~ s/_cheat_sheet//r;
+		$vars{cheat_sheet_hyphenated} = $underscored =~ s/_/-/gr;
+	}
+
 	# If the Perl module every becomes optional, this should only run if the user
 	# requests one
 	unless($no_handler){


### PR DESCRIPTION
@zachthompson This adds a template variable that can be used for the cheat sheet file name so we have hyphens rather than underscores.

Fixes #353.

This needs to be merged *before* duckduckgo/zeroclickinfo-goodies#3337.