### PR TITLE
Pass Spice call_data to JS Spice object

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -273,6 +273,7 @@ sub request {
 		my @calls_nrc = ();
 		my @calls_script = ();
 		my %calls_template = ();
+		my %calls_data = ();
 		my @calls_goodie;
 		my @ids;
 
@@ -347,9 +348,15 @@ sub request {
 			my $result_type =	($res_ref eq 'DDG::ZeroClickInfo::Spice') ? 'spice' :
 								($res_ref eq 'DDG::ZeroClickInfo') ?		'goodie' :
 																			'other';
+
 			my $is_goodie = $result_type eq 'goodie';
-			if (($result_type eq 'spice' || $is_goodie)
-				&& $caller->can('module_share_dir')) {
+			my $is_spice  = $result_type eq 'spice';
+
+			if ($is_spice && $result->has_call_data){
+				$calls_data{$id} = $result->call_data;
+			}
+
+			if (($is_spice || $is_goodie) && $caller->can('module_share_dir')) {
 				# grab associated JS, Handlebars and CSS
 				# and add them to correct arrays for injection into page
 				my $share_dir = path($caller->module_share_dir);
@@ -465,19 +472,38 @@ sub request {
 		#   calls_template : handlebars templates
 
 		my $calls_nrj = join('', map{ DDG::Meta::Data->get_js(id => $_) } @ids);
-		my $calls_script = join('', map { q|<script type='text/JavaScript' src='| . $_ . q|'></script>| } @calls_script);
+		my $calls_script = join('', map { qq|<script type='text/JavaScript' src='$_'></script>| } @calls_script);
 		# For now we only allow a single goodie. If that changes, we will do the
 		# same join/map as with spices.
-		if(@calls_goodie){
+		if (@calls_goodie) {
 			my $goodie = shift @calls_goodie;
+			my $goodie_json = encode_json($goodie);
 			$calls_nrj .= "DDG.duckbar.future_signal_tab({signal:'high',from:'$goodie->{id}'});",
 			# Uncomment following line and remove "setTimeout" line when javascript race condition is addressed
 			# $calls_script = q|<script type="text/JavaScript">/*DDH.add(| . encode_json($goodie) . q|);*/</script>|;
-			$calls_script .= q|<script type="text/JavaScript">DDG.ready(function(){ window.setTimeout(DDH.add.bind(DDH, | . encode_json($goodie) . q|), 100)});</script>|;
+			$calls_script .= qq|
+				<script type="text/JavaScript">
+					DDG.ready(function(){
+						window.setTimeout( DDH.add($goodie_json), 100);
+					});
+				</script>|;
 		}
-		else{
+		else {
 			$calls_nrj .= @calls_nrj ? join(';', map { "nrj('".$_."')" } @calls_nrj) . ';' : '';
 		}
+
+		if (%calls_data) {
+			foreach my $spice_id ( keys %calls_data ){
+				my $json_data = encode_json($calls_data{$spice_id});
+				$calls_script .= qq|
+					<script type="text/JavaScript">
+						DDG.ready(function(){
+							Spice.$spice_id.call_data = $json_data;
+						});
+					</script>|;
+			}
+		}
+
 		my $calls_nrc = @calls_nrc ? join(';', map { "nrc('".$_."')" } @calls_nrc) . ';' : '';
 
 		if (%calls_template) {

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -498,7 +498,7 @@ sub request {
 				$calls_script .= qq|
 					<script type="text/JavaScript">
 						DDG.ready(function(){
-							Spice.$spice_id.call_data = $json_data;
+							DDG.inject('Spice.$spice_id.call_data', $json_data);
 						});
 					</script>|;
 			}


### PR DESCRIPTION
## Background

There was some recent discussion asking if we could formalize the weird script tag hack we have in place for grabbing extra data passed along from the Perl. (i.e. we parse the api call `<script>` tag to pull out useful information, like the parsed query)

I don't want us to formalize that weird hack and remembered that I had experimented with the `call_data` parameter before. Now that we're passing Perl data to the front end for Goodies I decided to take another stab at this, using the [`DDG.inject`](https://github.com/duckduckgo/duckduckgo-utils/blob/master/util.js#L325) function, which we use internally in a similar fashion.
## Result

This should allow us to easily pass extra data from Perl along to a front end Spice IA object.

I've tested this and it seems to be working correctly, getting it to work internally will really prove my theory.
## Testing

To test this, I modified the NPM Spice's `handle` function to:

``` perl
handle remainder_lc => sub {
    return unless $_;
    return $_, data(
        is_this_working => "yes!",
        query => $req->query
    );
};
```

And updated the JS to log the `call_data` with `console.log(Spice.npm.call_data);` which worked as expected:

![npm_colors_at_duckduckgo_and_1____projects_zeroclickinfo-spice__perl__and_any_do](https://cloud.githubusercontent.com/assets/873785/16748478/4b9cc4f0-4792-11e6-87af-ba32851ea940.png)

The code for the modified NPM Spice is on GitHub here: https://github.com/duckduckgo/zeroclickinfo-spice/compare/zaahir/spice-call-data-example

You can test this PR by checking out that Spice branch and running `duckpan -I ../p5-app-duckpan/lib server`, the triggering the NPM Spice with `npm colors`. The console will contain the Spice Data object passed from the Perl

---

@zachthompson I'd like to hear your thoughts on this
