### PR TITLE
Skip several DDG::* dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,6 +38,9 @@ push_to = origin master
 [AutoPrereqs]
 skip = ^DDG::*
 
+[Run::AfterBuild]
+run = cpanm DDG --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
+
 [MetaNoIndex]
 directory = t/
 directory = xt/

--- a/dist.ini
+++ b/dist.ini
@@ -36,12 +36,7 @@ tag_format = %v
 push_to = origin master
 
 [AutoPrereqs]
-skip = ^DDG::Publisher
-skip = ^DDG::Spice
-skip = ^DDG::Goodie
-skip = ^DDG::Test
-skip = ^DDG::Meta
-
+skip = ^DDG::*
 
 [MetaNoIndex]
 directory = t/

--- a/dist.ini
+++ b/dist.ini
@@ -37,6 +37,11 @@ push_to = origin master
 
 [AutoPrereqs]
 skip = ^DDG::Publisher
+skip = ^DDG::Spice
+skip = ^DDG::Goodie
+skip = ^DDG::Test
+skip = ^DDG::Meta
+
 
 [MetaNoIndex]
 directory = t/


### PR DESCRIPTION
DuckPAN is trying to install several deps that aren't required (at least to install App::DuckPAN).  This is causing installs to fail for users without the ZCI or DDG repos already installed.

I confirmed this by installing DuckPAN via cpanm on a fresh Ubuntu machine with a brewed Perl 5.16

`DDG::Meta` is technically required for DuckPAN to work, but it can't be installed until DuckPAN is. So one solution is to have DuckPAN to install DDG immediately after install via a dzil plugin like [AfterBuild](https://metacpan.org/pod/Dist::Zilla::Plugin::Run::AfterBuild)

/cc @xaviervalarino @kotoshenya @GuiltyDolphin 