### PR TITLE
FatHeads - add support for trigger words

### DIFF
--- a/lib/App/DuckPAN/Fathead.pm
+++ b/lib/App/DuckPAN/Fathead.pm
@@ -64,8 +64,8 @@ has _trigger_re => (
 sub _build__trigger_re {
 	my ($self) = @_;
 	my @words = @{$self->_trigger_words};
-	my $text = '\b(?:' . (join '|', map { quotemeta $_ } @words) . ')\b';
-	return qr/$text/i;
+	my $text = join '|', map { quotemeta $_ } @words;
+	return qr/\b(?:$text)\b/i;
 }
 
 has output_txt => (

--- a/lib/App/DuckPAN/Fathead.pm
+++ b/lib/App/DuckPAN/Fathead.pm
@@ -37,21 +37,19 @@ sub _trigger_selected {
 
 has _trigger_words => (
 	is      => 'ro',
-	lazy    => 1,
 	builder => 1,
+	lazy    => 1,
 );
 
 sub _build__trigger_words {
 	my ($self) = @_;
 	my $tf = 'trigger_words.txt';
-	my $file;
-	if ($self->has_selected) {
-		$file = path("lib/fathead/", $self->selected, $tf);
-		unless ($file->exists){
-			my $full_path = $file->realpath;
-			$self->app->emit_error("No $tf was found in $full_path");
-			return [];
-		}
+	return [] unless $self->has_selected;
+	my $file = path("lib/fathead/", $self->selected, $tf);
+	unless ($file->exists){
+		my $full_path = $file->realpath;
+		$self->app->emit_debug("No $tf was found in $full_path");
+		return [];
 	}
 	chomp (my @words = $file->lines);
 	return \@words;

--- a/lib/App/DuckPAN/Fathead.pm
+++ b/lib/App/DuckPAN/Fathead.pm
@@ -35,6 +35,41 @@ sub _trigger_selected {
 	return $dir;
 }
 
+has _trigger_words => (
+	is      => 'ro',
+	lazy    => 1,
+	builder => 1,
+);
+
+sub _build__trigger_words {
+	my ($self) = @_;
+	my $tf = 'trigger_words.txt';
+	my $file;
+	if ($self->has_selected) {
+		$file = path("lib/fathead/", $self->selected, $tf);
+		unless ($file->exists){
+			my $full_path = $file->realpath;
+			$self->app->emit_error("No $tf was found in $full_path");
+			return [];
+		}
+	}
+	chomp (my @words = $file->lines);
+	return \@words;
+}
+
+has _trigger_re => (
+	is      => 'ro',
+	lazy    => 1,
+	builder => 1,
+);
+
+sub _build__trigger_re {
+	my ($self) = @_;
+	my @words = @{$self->_trigger_words};
+	my $text = '\b(?:' . (join '|', map { quotemeta $_ } @words) . ')\b';
+	return qr/$text/i;
+}
+
 has output_txt => (
 	is => 'rwp',
 	lazy => 1,
@@ -95,6 +130,8 @@ sub _search_output {
 
 	my ($self, $query) = @_;
 
+	my $trigger_re = $self->_trigger_re;
+	$query =~ s/^$trigger_re\s+|\s+$trigger_re$//;
 	my $result = $self->_db_lookup($query);
 
 	while ($result && $result->{type} eq 'R') {


### PR DESCRIPTION
This allows better emulation of the triggering on production by providing a means of specifying trigger words.

Currently just accepts a `trigger_words.txt` file in the same directory as `output.txt` (not required) for trigger words; we could potentially have a CL option as well.

cc @moollaza @jbarrett 
