### PR TITLE
Ensure metadata is checked when no Instant Answers are specified

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -442,8 +442,6 @@ sub get_ia_by_name {
 			? DDG::Meta::Data->get_ia(id => $name)
 			: DDG::Meta::Data->get_ia(id => $self->camel_to_underscore($name));
 	}
-	$self->emit_and_exit(1, "No Instant Answer found with name '$name'")
-		unless defined $ia;
 	return $ia;
 }
 

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -50,13 +50,9 @@ sub get_blocks_from_current_dir {
 		} @args;
 		$self->app->fathead->selected(@fatheads);
 
-		my @clean_args = grep {
+		@args = grep {
 			$type->{name} eq "Spice" || $type->{name} eq "Goodie"
 		} @args;
-
-		@args = map {
-			$self->app->get_ia_by_name($_)->{perl_module}
-		} @clean_args;
 	}
 	require lib;
 	lib->import('lib');
@@ -71,9 +67,19 @@ sub get_blocks_from_current_dir {
 
 	my (%blocks_plugins, @UC_TRIGGERS);
 	# This loop goes through each Goodie / Spice, and it tries to load it.
-	foreach my $class (@args) {
+	foreach my $arg (@args) {
 		# Let's try to load each Goodie / Spice module
 		# and see if they load successfully.
+		my $class;
+		if (my $ia = $self->app->get_ia_by_name($arg)) {
+			$class = $ia->{perl_module};
+		}
+		else {
+			$failed_to_load{$arg} =
+				'Could not retrieve metadata - please ensure the Instant Answer page ' .
+				'is in development status or later.';
+			next;
+		}
 		my ($load_success, $load_error_message) = try_load_class($class);
 
 		# If they load successfully, $load_success would be a 1.

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -132,6 +132,11 @@ sub get_blocks_from_current_dir {
 	# Now let's tell the user why some of the modules failed.
 	$self->show_failed_modules(\%failed_to_load);
 
+	# Always bail if we have no Instant Answers to work with.
+	unless (@successfully_loaded || $self->app->fathead->selected) {
+		$self->app->emit_and_exit(1, "No Instant Answers loaded.");
+	}
+
 	if(@UC_TRIGGERS){
 		$self->app->emit_notice('Detected potential UPPERCASE triggers in the following instant answers. If yours is listed, check it out! Only lowercase will work.' . "\n"
 			. p(@UC_TRIGGERS, colored => $self->app->colors));


### PR DESCRIPTION
We were only performing a metadata existence check when IAs were specified (thus `duckpan query` did no checks); this PR fixes that.

cc @moollaza @zachthompson 