### PR TITLE
remove Before::Build step, DDG installed via cpan.org

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = App-DuckPAN
-author  = Torsten Raudssus <torsten@raudss.us> L<https://raudss.us/>
+author  = DuckDuckGo <open@duckduckgo.com>
 license = Apache_2_0
 copyright_holder = DuckDuckGo, Inc. L<https://duckduckgo.com/>
 copyright_year   = 2013
@@ -36,10 +36,7 @@ tag_format = %v
 push_to = origin master
 
 [AutoPrereqs]
-skip = ^DDG::*
-
-[Run::BeforeBuild]
-run = cpanm DDG --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
+skip = ^DDG::(Spice|Goodie|Fathead|Longtail|Publisher)
 
 [MetaNoIndex]
 directory = t/

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = App-DuckPAN
-author  = DuckDuckGo <open@duckduckgo.com>
+author  = DuckDuckGo <open@duckduckgo.com>, Zach Thompson <zach@duckduckgo.com>, Zaahir Moolla <moollaza@duckduckgo.com>, Torsten Raudssus <torsten@raudss.us> L<https://raudss.us/>
 license = Apache_2_0
 copyright_holder = DuckDuckGo, Inc. L<https://duckduckgo.com/>
 copyright_year   = 2013


### PR DESCRIPTION
We've now released the DDG repo to CPAN, so the DDG::Meta::Dependency can be installed as needed when DuckPAN installed. 

My attempted BeforeBuild fix can now be removed.

I've updated the list of DDG::* dependencies to be skipped as well.

/cc @zachthompson @jbarrett 