### PR TITLE
Failing to load metadata should be a warning

### DIFF
--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -77,8 +77,7 @@ sub get_blocks_from_current_dir {
 		else {
 			$failed_to_load{$arg} =
 				'Could not retrieve metadata - please ensure the Instant Answer page ' .
-				'is in development status or later.';
-			next;
+				'is in development status or later; the IA has still been loaded';
 		}
 		my ($load_success, $load_error_message) = try_load_class($class);
 

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -77,7 +77,7 @@ sub get_blocks_from_current_dir {
 		else {
 			$failed_to_load{$arg} =
 				'Could not retrieve metadata - please ensure the Instant Answer page ' .
-				'is in development status or later; the IA has still been loaded';
+				'is in development status or later; the IA has still been loaded.';
 		}
 		my ($load_success, $load_error_message) = try_load_class($class);
 


### PR DESCRIPTION
At the moment if an IA can't be found then the IA isn't loaded. This switches it out so it will still attempt to load the IA if the metadata is unavailable.

FWIW @moollaza thought this was already the case
