### PR TITLE
Add Fathead support to DuckPAN Test

### DIFF
--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -1,6 +1,7 @@
 package App::DuckPAN::Cmd::Test;
 # ABSTRACT: Command for running the tests of this library
 
+no warnings 'uninitialized';
 use MooX;
 with qw( App::DuckPAN::Cmd );
 
@@ -43,13 +44,14 @@ sub run {
 			# spaces - thus we grab the end of the package name.
 			$ia = $self->app->get_ia_by_name($ia);
 			my $id = $ia->{id};
-			my $perl_module = $ia->{perl_module} =~ /::(\w+)$/ ? $1 : '';
 
-			if (-d "t/$perl_module") {
-				push @to_test, "t/$perl_module";
-			}
-			elsif (my @test_file = File::Find::Rule->name("$perl_module.t")->in('t')) {
-				push @to_test, "@test_file";
+			if (my ($perl_module) = $ia->{perl_module} =~ /::(\w+)$/) {
+				if (-d "t/$perl_module") {
+					push @to_test, "t/$perl_module";
+				}
+				elsif (my @test_file = File::Find::Rule->name("$perl_module.t")->in('t')) {
+					push @to_test, "@test_file";
+				}
 			}
 			elsif ($ia_type eq 'Fathead') {
 				my $path = "lib/fathead/$id/output.txt";

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -1,7 +1,6 @@
 package App::DuckPAN::Cmd::Test;
 # ABSTRACT: Command for running the tests of this library
 
-no warnings 'uninitialized';
 use MooX;
 with qw( App::DuckPAN::Cmd );
 
@@ -16,6 +15,8 @@ option full => (
 	default => sub { 0 },
 	doc     => 'run full test suite via dzil',
 );
+
+no warnings 'uninitialized';
 
 sub run {
 	my ($self, @args) = @_;

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -53,7 +53,7 @@ sub run {
 					push @to_test, "@test_file";
 				}
 			}
-			elsif ($ia_type eq 'Fathead') {
+			if ($ia_type eq 'Fathead') {
 				my $path = "lib/fathead/$id/output.txt";
 				if (-f $path) {
 					$ENV{'DDG_TEST_FATHEAD'} = $id;

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -55,6 +55,7 @@ sub run {
 					push @to_test, "@test_file";
 				}
 			}
+
 			if ($ia_type eq 'Fathead') {
 				my $path = "lib/fathead/$id/output.txt";
 				if (-f $path) {
@@ -64,9 +65,8 @@ sub run {
 					$self->app->emit_and_exit(1, "Could not find output.txt for $id in $path");
 				}
 			}
-			else {
-				$self->app->emit_and_exit(1, "Could not find any tests for $id");
-			}
+
+			$self->app->emit_and_exit(1, "Could not find any tests for $id $ia_type") unless @to_test;
 		};
 		$self->app->emit_error('Tests failed! See output above for details') if @to_test           and $ret = system("prove -lr @to_test");
 		$self->app->emit_error('Tests failed! See output above for details') if @cheat_sheet_tests and $ret = system("prove -lr t/CheatSheets/CheatSheetsJSON.t :: @cheat_sheet_tests");

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -41,15 +41,14 @@ sub run {
 			}
 			# Unfortunately we can't just use the name, because some have
 			# spaces - thus we grab the end of the package name.
+			$ia = $self->app->get_ia_by_name($ia);
+			my $id = $ia->{id};
+			my $perl_module = $ia->{perl_module} =~ /::(\w+)$/ ? $1 : '';
 
-			my $id = $self->app->get_ia_by_name($ia)->{id};
-			$ia = $self->app->get_ia_by_name($ia)->{perl_module} =~ /::(\w+)$/;
-			$ia = $1;
-
-			if (-d "t/$ia") {
-				push @to_test, "t/$ia";
+			if (-d "t/$perl_module") {
+				push @to_test, "t/$perl_module";
 			}
-			elsif (my @test_file = File::Find::Rule->name("$ia.t")->in('t')) {
+			elsif (my @test_file = File::Find::Rule->name("$perl_module.t")->in('t')) {
 				push @to_test, "@test_file";
 			}
 			elsif ($ia_type eq 'Fathead') {
@@ -58,11 +57,11 @@ sub run {
 					$ENV{'DDG_TEST_FATHEAD'} = $id;
 					push @to_test, "t/validate_fathead.t";
 				} else {
-					$self->app->emit_and_exit(1, "Could not find output.txt for $ia in $path");
+					$self->app->emit_and_exit(1, "Could not find output.txt for $id in $path");
 				}
 			}
 			else {
-				$self->app->emit_and_exit(1, "Could not find any tests for $ia");
+				$self->app->emit_and_exit(1, "Could not find any tests for $id");
 			}
 		};
 		$self->app->emit_error('Tests failed! See output above for details') if @to_test           and $ret = system("prove -lr @to_test");

--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -32,18 +32,19 @@ sub run {
 	else {
 		my @to_test = ('t') unless @args;
 		my @cheat_sheet_tests;
-		foreach my $ia (@args) {
-			if ($ia =~ /_cheat_sheet$/) {
+		foreach my $ia_name (@args) {
+			if ($ia_name =~ /_cheat_sheet$/) {
 				$self->app->emit_and_exit(1, 'Cheat sheets can only be tested in Goodies')
 					unless $ia_type eq 'Goodie';
-				$ia =~ s/_cheat_sheet$//;
-				$ia =~ s/_/-/g;
-				push @cheat_sheet_tests, $ia;
+				$ia_name =~ s/_cheat_sheet$//;
+				$ia_name =~ s/_/-/g;
+				push @cheat_sheet_tests, $ia_name;
 				next;
 			}
 			# Unfortunately we can't just use the name, because some have
 			# spaces - thus we grab the end of the package name.
-			$ia = $self->app->get_ia_by_name($ia);
+			my $ia = $self->app->get_ia_by_name($ia_name);
+			$self->app->emit_and_exit(1, "Could not find an Instant Answer with name '$ia_name'") unless $ia;
 			my $id = $ia->{id};
 
 			if (my ($perl_module) = $ia->{perl_module} =~ /::(\w+)$/) {


### PR DESCRIPTION
- Allow `duckpan test` to check if named Instant Answer ID has a valid `/lib/fathead` dir containing an `output.txt`
- If so, modify `$ENV` accordingly for `validate_fathead.t`

/cc @jbarrett 