### PR TITLE
Remove Metadata requirement for IAs to run in DuckPAN

### DIFF
--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -27,8 +27,6 @@ use open qw/:std :utf8/;
 use App::DuckPAN::Cmd::Help;
 use DDG::Meta::Data;
 
-use Data::Printer;
-
 no warnings 'uninitialized';
 
 option dev_version => (
@@ -438,26 +436,12 @@ sub get_ia_by_name {
 
 	if ($name =~ /^DDG::/) {
 		$ia = DDG::Meta::Data->get_ia(module => $name);
-		p($ia);
 		$ia = $ia->[0] if $ia;
 	}
 	else {
 		$ia = $name =~ /_/
 			? DDG::Meta::Data->get_ia(id => $name)
 			: DDG::Meta::Data->get_ia(id => $self->camel_to_underscore($name));
-	}
-
-	unless ($ia) {
-		my @msg = (
-			"Could not retrieve Instant Answers Metadata for: $name.",
-			"Using temporary Metadata instead.\n",
-			"If you have created an IA Page, please ensure it is in 'development' status or later.",
-			"To update the IA Page status, you will need to open a Pull Request.",
-			"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
-		);
-		$self->emit_notice(@msg);
-
-		$ia = { perl_module => $name };
 	}
 
 	return $ia;

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -441,14 +441,15 @@ sub get_ia_by_name {
 		}
 		else {
 			my @msg = (
-				"Could not retrieve metadata for: $name.",
+				"Could not retrieve Instant Answers Metadata for: $name.",
+				"Using temporary Metadata instead.\n",
 				"If you have created an IA Page, please ensure it is in 'development' status or later.",
 				"To update the IA Page status, you will need to open a Pull Request.",
 				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
 			);
 			$self->emit_notice(@msg);
 
-			$ia = { perl_module => $name, id => 'answer'};
+			$ia = { perl_module => $name };
 		}
 	}
 	else {

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -27,6 +27,8 @@ use open qw/:std :utf8/;
 use App::DuckPAN::Cmd::Help;
 use DDG::Meta::Data;
 
+use Data::Printer;
+
 no warnings 'uninitialized';
 
 option dev_version => (
@@ -436,27 +438,28 @@ sub get_ia_by_name {
 
 	if ($name =~ /^DDG::/) {
 		$ia = DDG::Meta::Data->get_ia(module => $name);
-		if ($ia) {
-			$ia = $ia->[0];
-		}
-		else {
-			my @msg = (
-				"Could not retrieve Instant Answers Metadata for: $name.",
-				"Using temporary Metadata instead.\n",
-				"If you have created an IA Page, please ensure it is in 'development' status or later.",
-				"To update the IA Page status, you will need to open a Pull Request.",
-				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
-			);
-			$self->emit_notice(@msg);
-
-			$ia = { perl_module => $name };
-		}
+		p($ia);
+		$ia = $ia->[0] if $ia;
 	}
 	else {
 		$ia = $name =~ /_/
 			? DDG::Meta::Data->get_ia(id => $name)
 			: DDG::Meta::Data->get_ia(id => $self->camel_to_underscore($name));
 	}
+
+	unless ($ia) {
+		my @msg = (
+			"Could not retrieve Instant Answers Metadata for: $name.",
+			"Using temporary Metadata instead.\n",
+			"If you have created an IA Page, please ensure it is in 'development' status or later.",
+			"To update the IA Page status, you will need to open a Pull Request.",
+			"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
+		);
+		$self->emit_notice(@msg);
+
+		$ia = { perl_module => $name };
+	}
+
 	return $ia;
 }
 

--- a/lib/App/DuckPAN.pm
+++ b/lib/App/DuckPAN.pm
@@ -433,9 +433,23 @@ sub phrase_to_camel {
 sub get_ia_by_name {
 	my ($self, $name) = @_;
 	my $ia;
+
 	if ($name =~ /^DDG::/) {
 		$ia = DDG::Meta::Data->get_ia(module => $name);
-		$ia = $ia->[0] if $ia;
+		if ($ia) {
+			$ia = $ia->[0];
+		}
+		else {
+			my @msg = (
+				"Could not retrieve metadata for: $name.",
+				"If you have created an IA Page, please ensure it is in 'development' status or later.",
+				"To update the IA Page status, you will need to open a Pull Request.",
+				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
+			);
+			$self->emit_notice(@msg);
+
+			$ia = { perl_module => $name, id => 'answer'};
+		}
 	}
 	else {
 		$ia = $name =~ /_/

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -190,7 +190,7 @@ sub change_js {
 }
 
 # Rewrite all relative asset links in CSS
-# Capture leading quote, insert
+# Capture leading quote, insert $hostname, append filename
 # E.g url("/assets/background.png") => url("http://duckduckgo.com/assets")
 sub change_css {
 	my ( $self, $css ) = @_;

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -191,7 +191,7 @@ sub change_js {
 
 # Rewrite all relative asset links in CSS
 # Capture leading quote, insert $hostname, append filename
-# E.g url("/assets/background.png") => url("http://duckduckgo.com/assets")
+# E.g url("/assets/background.png") => url("http://duckduckgo.com/assets/background.png")
 sub change_css {
 	my ( $self, $css ) = @_;
 	my $hostname = $self->hostname;

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -195,8 +195,7 @@ sub change_js {
 sub change_css {
 	my ( $self, $css ) = @_;
 	my $hostname = $self->hostname;
-
-	$css =~ s|:\s*url\(["']([^'"]+)["']\)|:url\("http://$hostname/$1")|gi;
+	$css =~ s!:\s*url\((["'])?/!:url\($1http://$hostname/!g;
 	return $css;
 }
 

--- a/lib/App/DuckPAN/Cmd/Server.pm
+++ b/lib/App/DuckPAN/Cmd/Server.pm
@@ -190,11 +190,13 @@ sub change_js {
 }
 
 # Rewrite all relative asset links in CSS
+# Capture leading quote, insert
 # E.g url("/assets/background.png") => url("http://duckduckgo.com/assets")
 sub change_css {
 	my ( $self, $css ) = @_;
 	my $hostname = $self->hostname;
-	$css =~ s!:\s*url\((["'])?/!:url\($1http://$hostname/!g;
+
+	$css =~ s|:\s*url\(["']([^'"]+)["']\)|:url\("http://$hostname/$1")|gi;
 	return $css;
 }
 

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -74,11 +74,29 @@ sub get_blocks_from_current_dir {
 		if (my $ia = $self->app->get_ia_by_name($arg)) {
 			$class = $ia->{perl_module};
 		}
+		elsif ($arg =~ /_/) {
+			my @msg = (
+				"Could not retrieve Instant Answers Metadata for ID: $arg.",
+				"If a local Perl Module exists, please provide the module name instead of the ID.",
+				"Or, if you have created an IA Page, please ensure it is in 'development' status or later.",
+				"To update the IA Page status, you will need to open a Pull Request.",
+				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
+			);
+			$self->app->emit_notice(@msg);
+		}
 		else {
-			$failed_to_load{$arg} =
-				'Could not retrieve metadata - please ensure the Instant Answer page ' .
-				'is in development status or later.';
-			next;
+			my @msg = (
+				"Could not retrieve Instant Answers Metadata for: $arg.",
+				"Using temporary Metadata instead.",
+				"If you have created an IA Page, please ensure it is in 'development' status or later.",
+				"To update the IA Page status, you will need to open a Pull Request.",
+				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
+			);
+			$self->app->emit_notice(@msg);
+			($class) = $arg =~ /DDG::/
+				? $arg
+				: "DDG::" . $type->{name} . "::$arg";
+			$self->app->emit_notice("Attempting to load local module: $class");
 		}
 		my ($load_success, $load_error_message) = try_load_class($class);
 

--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -9,17 +9,33 @@ use Class::Load ':all';
 use Data::Printer return_value => 'dump';
 use List::Util qw (first);
 
-# This function tells the user which modules / instant answers failed to load.
+# This function tells the user which modules / Instant Answers failed to load
 sub show_failed_modules {
 	my ($self, $failed_to_load) = @_;
 
 	if (%$failed_to_load) {
-		$self->app->emit_notice("These instant answers were not loaded:");
+		$self->app->emit_notice("These Instant Answers were not loaded:");
 		$self->app->emit_notice(p($failed_to_load, colored => $self->app->colors));
 		$self->app->emit_notice(
 			"To learn more about installing Perl dependencies, please read http://docs.duckduckhack.com/resources/other-dev-environments.html#dealing-with-installation-issues.",
-			"Note: You can ignore these errors if you're not working on these instant answers."
+			"Note: You can ignore these errors if you're not working on these Instant Answers."
 		) if first { /dependencies/ } values %$failed_to_load;
+	}
+}
+
+# This function tells the user which modules / Instant Answers have no associated metadata
+sub show_no_metadata_modules {
+	my ($self, $no_metadata) = @_;
+
+	if (@$no_metadata) {
+		$self->app->emit_notice("No metadata was found for these Instant Answers:");
+		$self->app->emit_notice(p($no_metadata, colored => $self->app->colors));
+		$self->app->emit_notice(
+			"Using temporary Metadata instead.",
+			"If you have created an IA Page, please ensure it is in 'development' status or later.",
+			"To update the IA Page status, you will need to open a Pull Request.",
+			"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
+		);
 	}
 }
 
@@ -65,6 +81,8 @@ sub get_blocks_from_current_dir {
 	# The key contains the module name and the value contains the dependency that wasn't met.
 	my %failed_to_load;
 
+	my @no_metadata;
+
 	my (%blocks_plugins, @UC_TRIGGERS);
 	# This loop goes through each Goodie / Spice, and it tries to load it.
 	foreach my $arg (@args) {
@@ -78,25 +96,17 @@ sub get_blocks_from_current_dir {
 			my @msg = (
 				"Could not retrieve Instant Answers Metadata for ID: $arg.",
 				"If a local Perl Module exists, please provide the module name instead of the ID.",
-				"Or, if you have created an IA Page, please ensure it is in 'development' status or later.",
+				"Or, if you have created an IA Page for any of these, please ensure its status is 'development' or 'testing'.",
 				"To update the IA Page status, you will need to open a Pull Request.",
 				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
 			);
 			$self->app->emit_notice(@msg);
 		}
 		else {
-			my @msg = (
-				"Could not retrieve Instant Answers Metadata for: $arg.",
-				"Using temporary Metadata instead.",
-				"If you have created an IA Page, please ensure it is in 'development' status or later.",
-				"To update the IA Page status, you will need to open a Pull Request.",
-				"More info: https://docs.duckduckhack.com/submitting/submitting-overview.html\n"
-			);
-			$self->app->emit_notice(@msg);
+			push @no_metadata, $arg;
 			($class) = $arg =~ /DDG::/
 				? $arg
 				: "DDG::" . $type->{name} . "::$arg";
-			$self->app->emit_notice("Attempting to load local module: $class");
 		}
 		my ($load_success, $load_error_message) = try_load_class($class);
 
@@ -153,6 +163,9 @@ sub get_blocks_from_current_dir {
 	# and @successfully_loaded does, we just use what's in @successfully_loaded.
 	@args = @successfully_loaded;
 
+	# Now let's tell the user which Instant Answers have no metadata
+	$self->show_no_metadata_modules(\@no_metadata);
+
 	# Now let's tell the user why some of the modules failed.
 	$self->show_failed_modules(\%failed_to_load);
 
@@ -162,7 +175,7 @@ sub get_blocks_from_current_dir {
 	}
 
 	if(@UC_TRIGGERS){
-		$self->app->emit_notice('Detected potential UPPERCASE triggers in the following instant answers. If yours is listed, check it out! Only lowercase will work.' . "\n"
+		$self->app->emit_notice('Detected potential UPPERCASE triggers in the following Instant Answers. If yours is listed, check it out! Only lowercase will work.' . "\n"
 			. p(@UC_TRIGGERS, colored => $self->app->colors));
 	}
 

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -339,15 +339,17 @@ sub request {
 			my $caller = $result->caller;
 			my $id;
 			#exlude parent/child IAs like CheatSheets
-			if(my $ia = DDG::Meta::Data->get_ia(module => $caller)){
+			if (my $ia = DDG::Meta::Data->get_ia(module => $caller)){
 				if (@$ia == 1) {
 					$id = $ia->[0]{id};
-					push @ids, $id;
-				} else {
-					my $id = eval{ $caller->id };
-					push @ids, $id if $id;
 				}
 			}
+			else {
+				my $clean_module = $caller;
+				$clean_module =~ s/DDG::[^:]+:://;
+				$id = App::DuckPAN->camel_to_underscore($clean_module);
+			}
+			push @ids, $id;
 
 			# Info for terminal.
 			p($result) if $result;

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -343,6 +343,9 @@ sub request {
 				if (@$ia == 1) {
 					$id = $ia->[0]{id};
 					push @ids, $id;
+				} else {
+					my $id = eval{ $caller->id };
+					push @ids, $id if $id;
 				}
 			}
 

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -479,7 +479,10 @@ sub request {
 		#   calls_nrc : css calls
 		#   calls_template : handlebars templates
 
-		my $calls_nrj = join('', map{ DDG::Meta::Data->get_js(id => $_) } @ids);
+		my $calls_nrj = join('', map {
+			DDG::Meta::Data->get_js(id => $_)
+			|| qq(DDH.$_=DDH.$_||{};DDH.$_.meta={"tab":"Answer", "id":"$_"};)
+		} @ids);
 		my $calls_script = join('', map { q|<script type='text/JavaScript' src='| . $_ . q|'></script>| } @calls_script);
 		# For now we only allow a single goodie. If that changes, we will do the
 		# same join/map as with spices.


### PR DESCRIPTION
## Background
Devs shouldn't **_need_** an IA page in dev status to play with DuckPAN. 

With the switch to the Programming Mission, devs are currently force to open PRs to test any new IAs, which means they are required to open PRs for non-mission IAs as well, which bloats the repo with PRs.

We should enable DuckPAN to use temporary metadata in order to trigger local IA's and show results.

This will help keep the repos clean with only PRs for IAs that are real and intended to move forward.

## Changes
- Update DDG.pm to gracefully handle IAs without metadata and use a temporary `ID` based on the Perl module
- Update Web.pm to generate "fake" metadata when none exists to be passed along to frontend JS to create IA tab and display result
  - Also, notify user when no metadata was found, and that temporary metadata is being used instead. Provide better explanation of how to get real metadata and IA Page working
- Minor fix to Server.pm that fixes warning

/cc @mintsoft 