### PR TITLE
Duckpan Test: Add verbose flag, set ENV variable for Tests to check

### DIFF
--- a/lib/App/DuckPAN/Cmd/Test.pm
+++ b/lib/App/DuckPAN/Cmd/Test.pm
@@ -16,10 +16,19 @@ option full => (
 	doc     => 'run full test suite via dzil',
 );
 
+option verbose => (
+	is      => 'ro',
+	short   => 'v',
+	default => sub { 0 },
+	doc     => 'verbose test output',
+);
+
 no warnings 'uninitialized';
 
 sub run {
 	my ($self, @args) = @_;
+
+	$ENV{'DDG_VERBOSE_TEST'} = $self->verbose;
 
 	my $ia_type = $self->app->get_ia_type->{name};
 
@@ -68,6 +77,7 @@ sub run {
 
 			$self->app->emit_and_exit(1, "Could not find any tests for $id $ia_type") unless @to_test;
 		};
+
 		$self->app->emit_error('Tests failed! See output above for details') if @to_test           and $ret = system("prove -lr @to_test");
 		$self->app->emit_error('Tests failed! See output above for details') if @cheat_sheet_tests and $ret = system("prove -lr t/CheatSheets/CheatSheetsJSON.t :: @cheat_sheet_tests");
 	}


### PR DESCRIPTION
## Background

Fathead output files can be tested with DuckPAN test, but sometimes they can dump thousands of lines of output if there are lots of errors for a big Fathead. This makes the test results very hard to read at a glance, and should be fixed.

## Changes

This adds a `verbose` flag to the `test` command. If it is present, DuckPAN sets an ENV variable (`DDG_VERBOSE_TEST`) that our test files can look for and use accordingly.

## Related Issues and Discussions
Associated Fathead test changes: https://github.com/duckduckgo/zeroclickinfo-fathead/pull/675