### PR TITLE
Pass spice headers to GET requests and print HTTP::Request in DuckPAN output

### DIFF
--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -189,23 +189,26 @@ sub request {
 					}
 
 					$to = "https://beta.duckduckgo.com$request_uri" if $use_ddh;
-					p($to);
 
 					my $h = HTTP::Headers->new( %$headers );
 					my $res;
+					my $req;
+
 					if ( $post_body && !$use_ddh ) {
-						$res = $self->ua->request(HTTP::Request->new(
+						$req = HTTP::Request->new(
 							POST => $to,
 							$h,
 							$post_body
-						));
+						);
 					}
 					else {
-						$res = $self->ua->request(HTTP::Request->new(
-							GET => $to,
-							$h
-						));
+						$req = HTTP::Request->new(
+							GET => $to
+						);
 					}
+
+					p($req->as_string);
+					$res = $self->ua->request($req);
 
 					if ($res->is_success) {
 						$body = $res->decoded_content;

--- a/lib/App/DuckPAN/Web.pm
+++ b/lib/App/DuckPAN/Web.pm
@@ -203,7 +203,8 @@ sub request {
 					}
 					else {
 						$req = HTTP::Request->new(
-							GET => $to
+							GET => $to,
+							$h
 						);
 					}
 


### PR DESCRIPTION
When dealing with and debugging Spice IA's that use POST request and/or `spice headers` the developer is not able to see the POST request body, or the headers that are sent.

This minor change ensures that the full request for both GET and POST requests is displayed to the developer.

Also, this ensure that `spice headers` are also passed along when used with a GET request.

/cc @pjhampton 

---

Example output:

![1__zeroclickinfo-spice__duckpan_-i____p5-app-duckpan_lib_server__gcat_](https://cloud.githubusercontent.com/assets/873785/24219351/d42ef14c-0f1c-11e7-860f-efc521453a9d.png)
