### PR TITLE
Corrected regex for CamelCase package names

### DIFF
--- a/lib/App/DuckPAN/DDG.pm
+++ b/lib/App/DuckPAN/DDG.pm
@@ -114,7 +114,7 @@ sub get_blocks_from_current_dir {
 
 		# Check if Perl Package name provided
 		# We don't have Goodie packages with
-		elsif ($arg =~ /^(DDG::(?:Goodie|Spice|Fathead)::)?[A-Z]+[a-z0-9]*?$/) {
+		elsif ($arg =~ /^(DDG::(?:Goodie|Spice|Fathead)::)?[A-Z]+[a-zA-Z0-9]*$/) {
 			push @no_metadata, $arg;
 			$class = $1 ? $arg : "DDG::$type->{name}::$arg";
 		}


### PR DESCRIPTION
User reported that a new IA, `DDG::Spice::AnimeTest` wasn't loading.

I've updated the package name regex to properly handle CamelCase names so that uppercase letters can follow lowercased letters 👍 

/cc @pjhampton (this may have affected you recently as well!)

